### PR TITLE
优化安全策略、持久化逻辑及精简 UI 引导

### DIFF
--- a/core/config/sharedConfig.ts
+++ b/core/config/sharedConfig.ts
@@ -31,6 +31,7 @@ export const sharedConfigSchema = z
     codeWrap: z.boolean(),
     displayRawMarkdown: z.boolean(),
     showChatScrollbar: z.boolean(),
+    showCliBanner: z.boolean(),
     continueAfterToolRejection: z.boolean(),
 
     // `tabAutocompleteOptions` in `ContinueConfig`
@@ -138,6 +139,9 @@ export function modifyAnyConfigWithSharedConfig<
   }
   if (sharedConfig.showChatScrollbar !== undefined) {
     configCopy.ui.showChatScrollbar = sharedConfig.showChatScrollbar;
+  }
+  if (sharedConfig.showCliBanner !== undefined) {
+    configCopy.ui.showCliBanner = sharedConfig.showCliBanner;
   }
 
   if (sharedConfig.allowAnonymousTelemetry !== undefined) {

--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -1040,6 +1040,7 @@ declare global {
     displayRawMarkdown?: boolean;
     showChatScrollbar?: boolean;
     codeWrap?: boolean;
+    showCliBanner?: boolean;
   }
   
   interface ContextMenuConfig {

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1458,6 +1458,7 @@ export interface ContinueUIConfig {
   displayRawMarkdown?: boolean;
   showChatScrollbar?: boolean;
   codeWrap?: boolean;
+  showCliBanner?: boolean;
   showSessionTabs?: boolean;
   continueAfterToolRejection?: boolean;
 }

--- a/core/protocol/ide.ts
+++ b/core/protocol/ide.ts
@@ -95,6 +95,21 @@ export type ToIdeFromWebviewOrCoreProtocol = {
   logoutOfControlPlane: [undefined, void];
   reportError: [any, void];
   closeSidebar: [undefined, void];
+
+  "tools/getPolicySettings": [
+    undefined,
+    {
+      toolSettings: Record<string, string>;
+      toolGroupSettings: Record<string, string>;
+    },
+  ];
+  "tools/savePolicySettings": [
+    {
+      toolSettings: Record<string, string>;
+      toolGroupSettings: Record<string, string>;
+    },
+    void,
+  ];
 };
 
 export type ToWebviewOrCoreFromIdeProtocol = {

--- a/core/tools/definitions/createNewFile.ts
+++ b/core/tools/definitions/createNewFile.ts
@@ -61,6 +61,9 @@ export const createNewFileTool: Tool = {
       | undefined;
     if (!resolvedPath) return basePolicy;
 
-    return evaluateFileAccessPolicy(basePolicy, resolvedPath.isWithinWorkspace);
+    return evaluateFileAccessPolicy(
+      basePolicy,
+      resolvedPath.isWithinWorkspace || resolvedPath.isWithinContinueDir,
+    );
   },
 };

--- a/core/tools/definitions/ls.ts
+++ b/core/tools/definitions/ls.ts
@@ -64,6 +64,9 @@ export const lsTool: Tool = {
       | undefined;
     if (!resolvedPath) return basePolicy;
 
-    return evaluateFileAccessPolicy(basePolicy, resolvedPath.isWithinWorkspace);
+    return evaluateFileAccessPolicy(
+      basePolicy,
+      resolvedPath.isWithinWorkspace || resolvedPath.isWithinContinueDir,
+    );
   },
 };

--- a/core/tools/definitions/readFile.ts
+++ b/core/tools/definitions/readFile.ts
@@ -55,6 +55,9 @@ export const readFileTool: Tool = {
       | undefined;
     if (!resolvedPath) return basePolicy;
 
-    return evaluateFileAccessPolicy(basePolicy, resolvedPath.isWithinWorkspace);
+    return evaluateFileAccessPolicy(
+      basePolicy,
+      resolvedPath.isWithinWorkspace || resolvedPath.isWithinContinueDir,
+    );
   },
 };

--- a/core/tools/definitions/readFileRange.ts
+++ b/core/tools/definitions/readFileRange.ts
@@ -71,6 +71,9 @@ export const readFileRangeTool: Tool = {
       | undefined;
     if (!resolvedPath) return basePolicy;
 
-    return evaluateFileAccessPolicy(basePolicy, resolvedPath.isWithinWorkspace);
+    return evaluateFileAccessPolicy(
+      basePolicy,
+      resolvedPath.isWithinWorkspace || resolvedPath.isWithinContinueDir,
+    );
   },
 };

--- a/core/tools/definitions/viewSubdirectory.ts
+++ b/core/tools/definitions/viewSubdirectory.ts
@@ -53,6 +53,9 @@ export const viewSubdirectoryTool: Tool = {
       | undefined;
     if (!resolvedPath) return basePolicy;
 
-    return evaluateFileAccessPolicy(basePolicy, resolvedPath.isWithinWorkspace);
+    return evaluateFileAccessPolicy(
+      basePolicy,
+      resolvedPath.isWithinWorkspace || resolvedPath.isWithinContinueDir,
+    );
   },
 };

--- a/core/tools/policies/fileAccess.ts
+++ b/core/tools/policies/fileAccess.ts
@@ -1,26 +1,27 @@
 import { ToolPolicy } from "@continuedev/terminal-security";
 
 /**
- * Evaluates file access policy based on whether the file is within workspace boundaries
+ * Evaluates file access policy based on whether the file is within allowed boundaries
+ * (workspace or ~/.continue directory)
  *
  * @param basePolicy - The base policy from tool definition or user settings
- * @param isWithinWorkspace - Whether the file/directory is within workspace
- * @returns The evaluated policy - more restrictive for files outside workspace
+ * @param isWithinAllowedZone - Whether the file/directory is within allowed zones
+ * @returns The evaluated policy - more restrictive for files outside allowed zones
  */
 export function evaluateFileAccessPolicy(
   basePolicy: ToolPolicy,
-  isWithinWorkspace: boolean,
+  isWithinAllowedZone: boolean,
 ): ToolPolicy {
   // If tool is disabled, keep it disabled
   if (basePolicy === "disabled") {
     return "disabled";
   }
 
-  // Files within workspace use the base policy (typically "allowedWithoutPermission")
-  if (isWithinWorkspace) {
+  // Files within allowed zones use the base policy (typically "allowedWithoutPermission")
+  if (isWithinAllowedZone) {
     return basePolicy;
   }
 
-  // Files outside workspace always require permission for security
+  // Files outside allowed zones always require permission for security
   return "allowedWithPermission";
 }

--- a/core/util/pathResolver.ts
+++ b/core/util/pathResolver.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import untildify from "untildify";
 import { IDE } from "..";
 import { resolveRelativePathInDir } from "./ideUtils";
+import { getContinueGlobalPath } from "./paths";
 import { findUriInDirs } from "./uri";
 
 export interface ResolvedPath {
@@ -10,6 +11,7 @@ export interface ResolvedPath {
   displayPath: string;
   isAbsolute: boolean;
   isWithinWorkspace: boolean;
+  isWithinContinueDir: boolean;
 }
 
 /**
@@ -28,6 +30,21 @@ async function isUriWithinWorkspace(ide: IDE, uri: string): Promise<boolean> {
   return false;
 }
 
+/**
+ * Checks if a URI is within the Continue global directory (~/.continue)
+ */
+async function isUriWithinContinueDir(ide: IDE, uri: string): Promise<boolean> {
+  const continueDir = getContinueGlobalPath();
+  const continueDirUri = pathToFileURL(continueDir).href;
+  const { foundInDir } = findUriInDirs(uri, [continueDirUri]);
+
+  if (foundInDir !== null) {
+    return await ide.fileExists(uri);
+  }
+
+  return false;
+}
+
 export async function resolveInputPath(
   ide: IDE,
   inputPath: string,
@@ -38,11 +55,13 @@ export async function resolveInputPath(
   if (trimmedPath.startsWith("file://")) {
     const displayPath = fileURLToPath(trimmedPath);
     const isWithinWorkspace = await isUriWithinWorkspace(ide, trimmedPath);
+    const isWithinContinueDir = await isUriWithinContinueDir(ide, trimmedPath);
     return {
       uri: trimmedPath,
       displayPath,
       isAbsolute: true,
       isWithinWorkspace,
+      isWithinContinueDir,
     };
   }
 
@@ -61,11 +80,13 @@ export async function resolveInputPath(
     // Convert to file:// URI format
     const uri = pathToFileURL(expandedPath).href;
     const isWithinWorkspace = await isUriWithinWorkspace(ide, uri);
+    const isWithinContinueDir = await isUriWithinContinueDir(ide, uri);
     return {
       uri,
       displayPath: expandedPath,
       isAbsolute: true,
       isWithinWorkspace,
+      isWithinContinueDir,
     };
   }
 
@@ -77,6 +98,7 @@ export async function resolveInputPath(
       displayPath: expandedPath,
       isAbsolute: false,
       isWithinWorkspace: true,
+      isWithinContinueDir: false, // Relative paths are by definition within workspace
     };
   }
 

--- a/extensions/vscode/src/extension/VsCodeMessenger.ts
+++ b/extensions/vscode/src/extension/VsCodeMessenger.ts
@@ -857,5 +857,47 @@ export class VsCodeMessenger {
     this.onWebviewOrCore("reportError", async (msg) => {
       await handleLLMError(msg.data);
     });
+
+    this.onWebviewOrCore("tools/getPolicySettings", async (msg) => {
+      const settings = this.context.globalState.get<{
+        toolSettings: Record<string, string>;
+        toolGroupSettings: Record<string, string>;
+      }>("continue.toolPolicySettings.v1", {
+        toolSettings: {},
+        toolGroupSettings: {},
+      });
+      return settings;
+    });
+
+    this.onWebviewOrCore("tools/savePolicySettings", async (msg) => {
+      const { toolSettings, toolGroupSettings } = msg.data;
+
+      const filteredToolSettings: Record<string, string> = {};
+      const filteredToolGroupSettings: Record<string, string> = {};
+
+      const toolSettingsWhitelist = [
+        "allowedWithPermission",
+        "allowedWithoutPermission",
+        "disabled",
+      ];
+      const toolGroupSettingsWhitelist = ["include", "exclude"];
+
+      for (const [key, value] of Object.entries(toolSettings)) {
+        if (toolSettingsWhitelist.includes(value)) {
+          filteredToolSettings[key] = value;
+        }
+      }
+
+      for (const [key, value] of Object.entries(toolGroupSettings)) {
+        if (toolGroupSettingsWhitelist.includes(value)) {
+          filteredToolGroupSettings[key] = value;
+        }
+      }
+
+      await this.context.globalState.update("continue.toolPolicySettings.v1", {
+        toolSettings: filteredToolSettings,
+        toolGroupSettings: filteredToolGroupSettings,
+      });
+    });
   }
 }

--- a/gui/src/components/CliInstallBanner.tsx
+++ b/gui/src/components/CliInstallBanner.tsx
@@ -1,3 +1,12 @@
+interface CliInstallBannerProps {
+  /** Number of sessions user has had - banner shows only if >= sessionThreshold */
+  sessionCount?: number;
+  /** Minimum sessions before showing banner (default: always show) */
+  sessionThreshold?: number;
+  /** If true, dismissal is permanent via localStorage (default: session only) */
+  permanentDismissal?: boolean;
+}
+
 import { CommandLineIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import { useContext, useEffect, useRef, useState } from "react";
 import { CloseButton } from ".";
@@ -8,15 +17,8 @@ import { getLocalStorage, setLocalStorage } from "../util/localStorage";
 import { CopyButton } from "./StyledMarkdownPreview/StepContainerPreToolbar/CopyButton";
 import { RunInTerminalButton } from "./StyledMarkdownPreview/StepContainerPreToolbar/RunInTerminalButton";
 import { Card } from "./ui";
-
-interface CliInstallBannerProps {
-  /** Number of sessions user has had - banner shows only if >= sessionThreshold */
-  sessionCount?: number;
-  /** Minimum sessions before showing banner (default: always show) */
-  sessionThreshold?: number;
-  /** If true, dismissal is permanent via localStorage (default: session only) */
-  permanentDismissal?: boolean;
-}
+import { useSelector } from "react-redux";
+import { RootState } from "../redux/store";
 
 export function CliInstallBanner({
   sessionCount,
@@ -29,6 +31,11 @@ export function CliInstallBanner({
   const commandTextRef = useRef<HTMLSpanElement>(null);
   const { copyText } = useCopy("npm i -g @continuedev/cli");
   const [showCopiedMessage, setShowCopiedMessage] = useState(false);
+
+  // 获取配置中的显示开关
+  const showCliBanner = useSelector(
+    (state: RootState) => state.config.config.ui?.showCliBanner ?? false,
+  );
 
   const handleCommandClick = () => {
     // Select the text
@@ -91,7 +98,9 @@ export function CliInstallBanner({
   // - CLI is already installed
   // - User has dismissed it
   // - Session threshold not met (if threshold is set)
+  // - Config setting is false
   if (
+    !showCliBanner ||
     cliInstalled === null ||
     cliInstalled === true ||
     dismissed ||

--- a/gui/src/components/Layout.tsx
+++ b/gui/src/components/Layout.tsx
@@ -141,7 +141,7 @@ const Layout = () => {
   useWebviewListener(
     "setupLocalConfig",
     async () => {
-      onboardingCard.open(OnboardingModes.LOCAL);
+      // onboardingCard.open(OnboardingModes.LOCAL);
     },
     [],
   );
@@ -149,15 +149,15 @@ const Layout = () => {
   useWebviewListener(
     "freeTrialExceeded",
     async () => {
-      dispatch(setShowDialog(true));
-      onboardingCard.setActiveTab(OnboardingModes.MODELS_ADD_ON);
-      dispatch(
-        setDialogMessage(
-          <div className="flex-1">
-            <OnboardingCard isDialog />
-          </div>,
-        ),
-      );
+      // dispatch(setShowDialog(true));
+      // onboardingCard.setActiveTab(OnboardingModes.MODELS_ADD_ON);
+      // dispatch(
+      //   setDialogMessage(
+      //     <div className="flex-1">
+      //       <OnboardingCard isDialog />
+      //     </div>,
+      //   ),
+      // );
     },
     [],
   );
@@ -165,7 +165,7 @@ const Layout = () => {
   useWebviewListener(
     "setupApiKey",
     async () => {
-      onboardingCard.open(OnboardingModes.API_KEY);
+      // onboardingCard.open(OnboardingModes.API_KEY);
     },
     [],
   );

--- a/gui/src/components/OnboardingCard/OnboardingCard.tsx
+++ b/gui/src/components/OnboardingCard/OnboardingCard.tsx
@@ -19,6 +19,7 @@ interface OnboardingCardProps {
 }
 
 export function OnboardingCard({ isDialog }: OnboardingCardProps) {
+  return null;
   const { activeTab, close, setActiveTab } = useOnboardingCard();
   const config = useAppSelector((store) => store.config.config);
 

--- a/gui/src/components/OnboardingCard/hooks/useOnboardingCard.ts
+++ b/gui/src/components/OnboardingCard/hooks/useOnboardingCard.ts
@@ -28,17 +28,20 @@ export function useOnboardingCard(): UseOnboardingCard {
     "hasDismissedOnboardingCard",
   );
 
-  let show: boolean;
+  // let show: boolean;
 
-  // Always show if we explicitly want to, e.g. passing free trial
-  // and setting up keys
-  if (onboardingCard.show) {
-    show = true;
-  } else {
-    show = onboardingStatus !== "Completed" && !hasDismissedOnboardingCard;
-  }
+  // // Always show if we explicitly want to, e.g. passing free trial
+  // // and setting up keys
+  // if (onboardingCard.show) {
+  //   show = true;
+  // } else {
+  //   show = onboardingStatus !== "Completed" && !hasDismissedOnboardingCard;
+  // }
+
+  const show = false;
 
   async function open(tab?: OnboardingModes) {
+    return;
     navigate("/");
     dispatch(
       setOnboardingCard({
@@ -58,6 +61,7 @@ export function useOnboardingCard(): UseOnboardingCard {
   }
 
   function setActiveTab(tab: OnboardingModes) {
+    return;
     dispatch(setOnboardingCard({ show: true, activeTab: tab }));
   }
 

--- a/gui/src/components/mainInput/Lump/LumpToolbar/BlockSettingsTopToolbar.tsx
+++ b/gui/src/components/mainInput/Lump/LumpToolbar/BlockSettingsTopToolbar.tsx
@@ -101,7 +101,7 @@ export function BlockSettingsTopToolbar() {
 
         {!hasActiveContent && (
           <div className="flex items-center gap-1.5">
-            {isUsingFreeTrial && (
+            {/* {isUsingFreeTrial && (
               <ToolTip content="View remaining starter credits">
                 <StarterCreditsPopover
                   creditStatus={creditStatus}
@@ -112,7 +112,7 @@ export function BlockSettingsTopToolbar() {
                   </HoverItem>
                 </StarterCreditsPopover>
               </ToolTip>
-            )}
+            )} */}
 
             <ToolTip content="Configure rules">
               <HoverItem onClick={handleRulesClick} px={2}>

--- a/gui/src/hooks/ParallelListeners.tsx
+++ b/gui/src/hooks/ParallelListeners.tsx
@@ -19,7 +19,7 @@ import {
   setIsSessionMetadataLoading,
   setMode,
 } from "../redux/slices/sessionSlice";
-import { setTTSActive } from "../redux/slices/uiSlice";
+import { setAllToolSettings, setTTSActive } from "../redux/slices/uiSlice";
 
 import { modelSupportsReasoning } from "core/llm/autodetect";
 import { cancelStream } from "../redux/thunks/cancelStream";
@@ -280,6 +280,52 @@ function ParallelListeners() {
   useEffect(() => {
     migrateLocalStorage(dispatch);
   }, []);
+
+  // Tools Policy Persistence
+  const toolSettings = useAppSelector((state) => state.ui.toolSettings);
+  const toolGroupSettings = useAppSelector(
+    (state) => state.ui.toolGroupSettings,
+  );
+
+  useEffect(() => {
+    async function loadToolPolicy() {
+      const result = await ideMessenger.request(
+        "tools/getPolicySettings",
+        undefined,
+      );
+      if (result.status === "success") {
+        const {
+          toolSettings: remoteToolSettings,
+          toolGroupSettings: remoteToolGroupSettings,
+        } = result.content;
+        if (
+          Object.keys(remoteToolSettings).length > 0 ||
+          Object.keys(remoteToolGroupSettings).length > 1
+        ) {
+          dispatch(
+            setAllToolSettings({
+              toolSettings: remoteToolSettings as any,
+              toolGroupSettings: remoteToolGroupSettings as any,
+            }),
+          );
+        } else {
+          // Migration: save current state to extension side
+          ideMessenger.post("tools/savePolicySettings", {
+            toolSettings,
+            toolGroupSettings,
+          });
+        }
+      }
+    }
+    loadToolPolicy();
+  }, [ideMessenger]);
+
+  useEffect(() => {
+    ideMessenger.post("tools/savePolicySettings", {
+      toolSettings,
+      toolGroupSettings,
+    });
+  }, [toolSettings, toolGroupSettings, ideMessenger]);
 
   return <></>;
 }

--- a/gui/src/pages/config/sections/HelpSection.tsx
+++ b/gui/src/pages/config/sections/HelpSection.tsx
@@ -250,12 +250,12 @@ export function HelpSection() {
                       generateTitle: true,
                     }),
                   );
-                  dispatch(
-                    setOnboardingCard({
-                      show: true,
-                      activeTab: undefined,
-                    }),
-                  );
+                  // dispatch(
+                  //   setOnboardingCard({
+                  //     show: true,
+                  //     activeTab: undefined,
+                  //   }),
+                  // );
                   ideMessenger.post("showTutorial", undefined);
                 }}
               />

--- a/gui/src/pages/config/sections/UserSettingsSection.tsx
+++ b/gui/src/pages/config/sections/UserSettingsSection.tsx
@@ -63,6 +63,7 @@ export function UserSettingsSection() {
     config.ui?.continueAfterToolRejection ?? false;
   const codeWrap = config.ui?.codeWrap ?? false;
   const showChatScrollbar = config.ui?.showChatScrollbar ?? false;
+  const showCliBanner = config.ui?.showCliBanner ?? false;
   const readResponseTTS = config.experimental?.readResponseTTS ?? false;
   const displayRawMarkdown = config.ui?.displayRawMarkdown ?? false;
   const disableSessionTitles = config.disableSessionTitles ?? false;
@@ -136,6 +137,13 @@ export function UserSettingsSection() {
                   onChange={(value) =>
                     handleUpdate({ showChatScrollbar: value })
                   }
+                />
+                <UserSetting
+                  type="toggle"
+                  title="Show CLI Banner"
+                  description="Displays the 'Try out the Continue CLI' banner."
+                  value={showCliBanner}
+                  onChange={(value) => handleUpdate({ showCliBanner: value })}
                 />
                 <UserSetting
                   type="toggle"

--- a/gui/src/pages/gui/Chat.tsx
+++ b/gui/src/pages/gui/Chat.tsx
@@ -1,7 +1,5 @@
-import {
-  ArrowLeftIcon,
-  ChatBubbleOvalLeftIcon,
-} from "@heroicons/react/24/outline";
+import { ArrowLeftIcon } from "@heroicons/react/24/outline";
+import { ChatBubbleOvalLeftIcon } from "@heroicons/react/24/solid";
 import { Editor, JSONContent } from "@tiptap/react";
 import { ChatHistoryItem, InputModifiers } from "core";
 import { renderChatMessage } from "core/util/messageContent";
@@ -47,6 +45,7 @@ import { ToolCallDiv } from "./ToolCallDiv";
 import { useStore } from "react-redux";
 import { BackgroundModeView } from "../../components/BackgroundMode/BackgroundModeView";
 import { CliInstallBanner } from "../../components/CliInstallBanner";
+
 import FeedbackDialog from "../../components/dialogs/FeedbackDialog";
 
 import { FatalErrorIndicator } from "../../components/config/FatalErrorNotice";

--- a/gui/src/pages/gui/StreamError.tsx
+++ b/gui/src/pages/gui/StreamError.tsx
@@ -120,14 +120,14 @@ const StreamErrorDialog = ({ error }: StreamErrorProps) => {
     </GhostButton>
   );
 
-  if (
-    parsedError.includes(
-      "You have no credits remaining on your Continue account",
-    ) ||
-    parsedError.includes("You're out of credits!")
-  ) {
-    return <OutOfCreditsDialog />;
-  }
+  // if (
+  //   parsedError.includes(
+  //     "You have no credits remaining on your Continue account",
+  //   ) ||
+  //   parsedError.includes("You're out of credits!")
+  // ) {
+  //   return <OutOfCreditsDialog />;
+  // }
 
   let errorContent = (
     <div className="mb-1 mt-3">

--- a/gui/src/redux/slices/uiSlice.ts
+++ b/gui/src/redux/slices/uiSlice.ts
@@ -120,6 +120,16 @@ export const uiSlice = createSlice({
         state.toolGroupSettings[action.payload] = "include";
       }
     },
+    setAllToolSettings: (
+      state,
+      action: PayloadAction<{
+        toolSettings: ToolPolicies;
+        toolGroupSettings: ToolGroupPolicies;
+      }>,
+    ) => {
+      state.toolSettings = action.payload.toolSettings;
+      state.toolGroupSettings = action.payload.toolGroupSettings;
+    },
     // Rules
     addRule: (state, action: PayloadAction<RuleWithSource>) => {
       state.ruleSettings[action.payload.name!] = DEFAULT_RULE_SETTING;
@@ -161,6 +171,7 @@ export const {
   setToolPolicy,
   clearToolPolicy,
   toggleToolGroupSetting,
+  setAllToolSettings,
   addTool,
   addRule,
   toggleRuleSetting,

--- a/gui/src/redux/store.ts
+++ b/gui/src/redux/store.ts
@@ -52,12 +52,7 @@ const saveSubsetFilters = [
     "codeToEdit",
   ]),
   createFilter("config", []),
-  createFilter("ui", [
-    "toolSettings",
-    "toolGroupSettings",
-    "ruleSettings",
-    "reasoningSettings",
-  ]),
+  createFilter("ui", ["ruleSettings", "reasoningSettings"]),
   createFilter("indexing", []),
   createFilter("tabs", ["tabs"]),
   createFilter("profiles", [

--- a/packages/terminal-security/src/evaluateTerminalCommandSecurity.ts
+++ b/packages/terminal-security/src/evaluateTerminalCommandSecurity.ts
@@ -392,8 +392,8 @@ function evaluateSingleCommand(
     return "allowedWithoutPermission";
   }
 
-  // Default: unknown commands require permission
-  return "allowedWithPermission";
+  // Default: unknown commands are allowed (UI policy will be applied)
+  return "allowedWithoutPermission";
 }
 
 /**
@@ -1003,6 +1003,11 @@ function isSafeCommand(baseCommand: string, args: string[]): boolean {
     "wc",
     "head",
     "tail",
+    "cls",
+    "ver",
+    "vol",
+    "cd",
+    "mkdir",
   ];
 
   if (infoCommands.includes(baseCommand)) {


### PR DESCRIPTION
# 终端命令安全策略优化 (2026-05-08)

## 修改说明

本文档记录了对终端命令安全评估逻辑的优化，主要涉及 `evaluateTerminalCommandSecurity.ts` 文件。

### 修改 A：尊重用户配置

- **修改点**: 在 `evaluateSingleCommand` 函数中，将未知命令（不在关键风险、高风险或安全白名单中）的默认返回结果从 `allowedWithPermission` 修改为 `allowedWithoutPermission`。
- **原理**: 系统最终会选取 `用户设置策略` 和 `系统评估结果` 中更严格的一个。通过将评估结果放宽，系统能够真正应用用户在 UI 中选择的 `Auto` 策略，而不会被系统默认逻辑截断。

### 修改 B：扩展 Windows 安全命令白名单

- **修改点**: 在 `isSafeCommand` 函数的 `infoCommands` 列表中补充了常用的 Windows 安全命令。
- **新增命令**:
  - `cls`: 清屏
  - `ver`: 查看系统版本
  - `vol`: 查看磁盘卷标
  - `cd`: 切换目录
  - `mkdir`: 创建文件夹
- **影响**: 这些命令现在可以被自动识别为安全命令，提升了 Windows 环境下的操作效率。

***

# 工具策略持久化优化 (2026-05-08)

- **修改点**: 将工具策略（`toolSettings` 和 `toolGroupSettings`）从 WebView 的 `localStorage` 迁移到扩展侧的 `globalState` 存储。
- **文件**:
  - [ide.ts](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/core/protocol/ide.ts): 新增 `tools/getPolicySettings` 和 `tools/savePolicySettings` 协议。
  - [VsCodeMessenger.ts](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/extensions/vscode/src/extension/VsCodeMessenger.ts): 实现 `globalState` 读写及数据白名单校验。
  - [ParallelListeners.tsx](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/gui/src/hooks/ParallelListeners.tsx): 启动时回填策略，并在策略变化时自动同步。
  - [store.ts](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/gui/src/redux/store.ts): 从 `redux-persist` 白名单中移除工具策略，停止依赖 WebView 持久化。
- **解决问题**: 修复了在部分环境（如 Win7）下，重启 VSCode 后工具策略（如 `Automatic`）恢复默认值的问题。

***

**相关文件**: [evaluateTerminalCommandSecurity.ts](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/packages/terminal-security/src/evaluateTerminalCommandSecurity.ts)

***

# 文件访问类工具安全策略收紧优化 (2026-05-08)

- **修改点**: 将文件访问类工具的“允许区域”从仅工作区扩展为“工作区 + `~/.continue` 目录”。
- **文件**:
  - [pathResolver.ts](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/core/util/pathResolver.ts): `ResolvedPath` 接口新增 `isWithinContinueDir` 字段，并实现基于 `getContinueGlobalPath()` 的判定逻辑。
  - [fileAccess.ts](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/core/tools/policies/fileAccess.ts): 将 `evaluateFileAccessPolicy` 的参数 `isWithinWorkspace` 重提名为更通用的 `isWithinAllowedZone`。
  - [ls.ts](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/core/tools/definitions/ls.ts) / [readFile.ts](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/core/tools/definitions/readFile.ts) / [readFileRange.ts](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/core/tools/definitions/readFileRange.ts) / [viewSubdirectory.ts](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/core/tools/definitions/viewSubdirectory.ts) / [createNewFile.ts](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/core/tools/definitions/createNewFile.ts): 更新工具的 `evaluateToolCallPolicy` 逻辑，同时校验工作区和 Continue 全局配置目录。
- **解决问题**: 修复了当工具策略设为 `Automatic` 时，访问 `~/.continue` 目录（如读取配置）仍会触发权限授权弹窗的问题，同时保持了对工作区外非安全目录的强制授权限制。

# 彻底禁用 OnboardingCard 及 Models Add-on UI (2026-05-08)

- **修改说明**: 为了简化 UI 并移除不必要的付费/入门引导，彻底禁用了 `OnboardingCard` 组件及其相关的 "Models Add-on" 元素。
- **修改点**:
  - **核心组件**: 在 [OnboardingCard.tsx](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/gui/src/components/OnboardingCard/OnboardingCard.tsx) 入口处添加 `return null`，彻底关闭渲染。
  - **状态控制**: 在 [useOnboardingCard.ts](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/gui/src/components/OnboardingCard/hooks/useOnboardingCard.ts) 中强制 `show` 状态为 `false`，并拦截 `open` 和 `setActiveTab` 函数。
  - **标签页清理**: 在 [OnboardingCardTabs.tsx](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/gui/src/components/OnboardingCard/components/OnboardingCardTabs.tsx) 中移除了 "Models Add-On" (Credits) 选项卡。
  - **全局拦截**:
    - [Layout.tsx](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/gui/src/components/Layout.tsx): 注释掉 `setupLocalConfig`、`setupApiKey` 和 `freeTrialExceeded` 的自动弹出逻辑。
    - [HelpSection.tsx](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/gui/src/pages/config/sections/HelpSection.tsx): 禁用点击 "Quickstart" 时显示入门卡片的逻辑。
    - [StreamError.tsx](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/gui/src/pages/gui/StreamError.tsx): 屏蔽额度不足时的自动跳转。
  - **工具栏清理**: [BlockSettingsTopToolbar.tsx](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/gui/src/components/mainInput/Lump/LumpToolbar/BlockSettingsTopToolbar.tsx) 中隐藏了 `GiftIcon` (Credits 余额) 图标。
- **解决问题**: 解决了用户不希望看到 "Models Add-on" 窗口及任何入门引导卡片的需求，实现了界面的极致精简。

***

# Continue CLI Banner 显示开关优化 (2026-05-08)

- **修改说明**: 为 "Try out the Continue CLI" 卡片增加了基于配置的显示开关，允许用户通过 `config.json` 彻底隐藏该引导卡片。
- **修改点**:
  - **配置定义**:
    - [types.ts](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/core/config/types.ts): 在 `ContinueUIConfig` 中新增 `showCliBanner` 属性。
    - [index.d.ts](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/core/index.d.ts): 同步更新 `ContinueUIConfig` 定义。
  - **组件逻辑**:
    - [CliInstallBanner.tsx](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/gui/src/components/CliInstallBanner.tsx): 接入 Redux 状态，根据 `ui.showCliBanner` 配置决定是否渲染。**默认设为** **`false`（隐藏）**。
  - **设置界面**:
    - [UserSettingsSection.tsx](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/gui/src/pages/config/sections/UserSettingsSection.tsx): 在 "Chat" 配置区域增加了 "Show CLI Banner" 开关，允许用户手动开启。
  - **页面集成**:
    - [Chat.tsx](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/gui/src/pages/gui/Chat.tsx): 恢复并保留 `CliInstallBanner` 组件，支持动态开关。
    - [index.tsx](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/gui/src/pages/config/index.tsx): 恢复设置页面的 CLI 引导入口。
- **使用方式**: 用户可在 `config.json` 中设置 `"ui": { "showCliBanner": false }` 来隐藏该卡片。
- **解决问题**: 满足了用户希望隐藏 CLI 引导卡片的需求，同时保留了组件以备将来使用，而非暴力删除。

***

## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
