### PR TITLE
修复登录闪现并优化会话与终端处理

### DIFF
--- a/core/tools/implementations/runTerminalCommand.ts
+++ b/core/tools/implementations/runTerminalCommand.ts
@@ -26,7 +26,16 @@ function getShellCommand(command: string): { shell: string; args: string[] } {
   if (process.platform === "win32") {
     return {
       shell: "powershell.exe",
-      args: ["-NoLogo", "-ExecutionPolicy", "Bypass", "-Command", command],
+      args: [
+        "-NoLogo",
+        "-NonInteractive",
+        "-InputFormat",
+        "None",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        command,
+      ],
     };
   } else {
     const userShell = process.env.SHELL || "/bin/bash";
@@ -170,7 +179,10 @@ export const runTerminalCommandImpl: ToolImpl = async (args, extras) => {
           const childProc = childProcess.spawn(shell, args, {
             cwd,
             env: getColorEnv(), // Add enhanced environment for colors
+            shell: process.platform === "win32",
           });
+
+          childProc.stdin?.end();
 
           // Track this process for foreground cancellation
           if (toolCallId && waitForCompletion) {
@@ -409,8 +421,11 @@ export const runTerminalCommandImpl: ToolImpl = async (args, extras) => {
                 {
                   cwd,
                   env: getColorEnv(),
+                  shell: process.platform === "win32",
                 },
               );
+
+              childProc.stdin?.end();
 
               // Track this process for foreground cancellation
               if (toolCallId) {

--- a/core/util/processTerminalStates.ts
+++ b/core/util/processTerminalStates.ts
@@ -1,4 +1,4 @@
-import { ChildProcess } from "child_process";
+import { ChildProcess, exec } from "child_process";
 
 // Track which processes have been backgrounded
 const processTerminalBackgroundStates = new Map<string, boolean>();
@@ -70,16 +70,25 @@ export function removeRunningProcess(toolCallId: string): void {
 export async function killTerminalProcess(toolCallId: string): Promise<void> {
   const processInfo = processTerminalForegroundStates.get(toolCallId);
   if (processInfo && !processInfo.process.killed) {
-    const { process } = processInfo;
+    const { process: childProc } = processInfo;
 
-    process.kill("SIGTERM");
-
-    // Force kill after 5 seconds if still running
-    setTimeout(() => {
-      if (!process.killed) {
-        process.kill("SIGKILL");
+    if (process.platform === "win32") {
+      try {
+        exec(`taskkill /pid ${childProc.pid} /T /F`);
+      } catch (e) {
+        console.error("Failed to taskkill process:", e);
+        childProc.kill("SIGKILL");
       }
-    }, 5000);
+    } else {
+      childProc.kill("SIGTERM");
+
+      // Force kill after 5 seconds if still running
+      setTimeout(() => {
+        if (!childProc.killed) {
+          childProc.kill("SIGKILL");
+        }
+      }, 5000);
+    }
 
     processTerminalForegroundStates.delete(toolCallId);
   }

--- a/extensions/vscode/src/ContinueGUIWebviewViewProvider.ts
+++ b/extensions/vscode/src/ContinueGUIWebviewViewProvider.ts
@@ -4,8 +4,8 @@ import { getControlPlaneEnv } from "core/control-plane/env";
 import { getTheme } from "./util/getTheme";
 import { getExtensionVersion, getvsCodeUriScheme } from "./util/util";
 import { getExtensionUri, getNonce, getUniqueId } from "./util/vscode";
-import { VsCodeWebviewProtocol } from "./webviewProtocol";
 import { VsCodeIde } from "./VsCodeIde";
+import { VsCodeWebviewProtocol } from "./webviewProtocol";
 
 import type { FileEdit } from "core";
 
@@ -14,6 +14,7 @@ export class ContinueGUIWebviewViewProvider
 {
   public static readonly viewType = "continue.continueGUIView";
   public webviewProtocol: VsCodeWebviewProtocol;
+  private _lastRenderedView: "app" | "login" | undefined;
 
   constructor(
     private readonly windowId: string,
@@ -45,22 +46,29 @@ export class ContinueGUIWebviewViewProvider
       console.log("ContinueGUIWebviewViewProvider: 收到 Webview 消息:", data);
       if (data.command === "login") {
         try {
-          const controlPlaneEnv = await getControlPlaneEnv(this.ide.getIdeSettings());
-          console.log("ContinueGUIWebviewViewProvider: 开始登录流程，AuthType:", controlPlaneEnv.AUTH_TYPE);
-          
+          const controlPlaneEnv = await getControlPlaneEnv(
+            this.ide.getIdeSettings(),
+          );
+          console.log(
+            "ContinueGUIWebviewViewProvider: 开始登录流程，AuthType:",
+            controlPlaneEnv.AUTH_TYPE,
+          );
+
           // 核心原理：调用 VS Code 的身份验证 API，触发 OAuth 流程
           // 强制触发新的 Session，无视可能挂起的缓存
           const session = await vscode.authentication.getSession(
             controlPlaneEnv.AUTH_TYPE,
             [],
-            { forceNewSession: true }
+            { forceNewSession: true },
           );
-          
+
           if (session) {
             console.log("登录成功:", session.account.label);
-            void vscode.window.showInformationMessage("登录成功: " + session.account.label);
+            void vscode.window.showInformationMessage(
+              "登录成功: " + session.account.label,
+            );
             // 登录成功后立即刷新 HTML 内容切换到 React 应用
-            this.updateWebviewHtml();
+            this.updateWebviewHtml(true);
           } else {
             console.warn("未获取到 Session，可能用户取消了登录");
             // 通知前端登录失败，重置按钮状态
@@ -80,12 +88,16 @@ export class ContinueGUIWebviewViewProvider
     // 监听登录状态变化
     // 原理：当用户完成登录或退出登录时，VS Code 会触发此事件。
     // 我们在此处更新 Webview 的内容，实现登录前后的无缝界面切换。
-    const authSubscription = vscode.authentication.onDidChangeSessions(async (e) => {
-      const controlPlaneEnv = await getControlPlaneEnv(this.ide.getIdeSettings());
-      if (e.provider.id === controlPlaneEnv.AUTH_TYPE) {
-        this.updateWebviewHtml();
-      }
-    });
+    const authSubscription = vscode.authentication.onDidChangeSessions(
+      async (e) => {
+        const controlPlaneEnv = await getControlPlaneEnv(
+          this.ide.getIdeSettings(),
+        );
+        if (e.provider.id === controlPlaneEnv.AUTH_TYPE) {
+          this.updateWebviewHtml();
+        }
+      },
+    );
     this.extensionContext.subscriptions.push(authSubscription);
 
     // 当 Webview 变得可见时，检查登录状态
@@ -95,49 +107,49 @@ export class ContinueGUIWebviewViewProvider
       if (webviewView.visible) {
         this.updateWebviewHtml();
         // 使用 promise 而不是 async/await
-        getControlPlaneEnv(this.ide.getIdeSettings()).then((controlPlaneEnv) => {
-          vscode.authentication.getSession(
-            controlPlaneEnv.AUTH_TYPE,
-            [],
-            { silent: true },
-          ).then((session) => {
-            if (!session) {
-              console.log("切换到插件且未登录，自动触发登录...");
-              // 添加一点延迟以确保 HTML 加载完毕
-              setTimeout(() => {
-                webviewView.webview.postMessage({ command: "triggerLogin" });
-              }, 500);
-            }
-          });
-        });
+        getControlPlaneEnv(this.ide.getIdeSettings()).then(
+          (controlPlaneEnv) => {
+            vscode.authentication
+              .getSession(controlPlaneEnv.AUTH_TYPE, [], { silent: true })
+              .then((session) => {
+                if (!session) {
+                  console.log("切换到插件且未登录，自动触发登录...");
+                  // 添加一点延迟以确保 HTML 加载完毕
+                  setTimeout(() => {
+                    webviewView.webview.postMessage({
+                      command: "triggerLogin",
+                    });
+                  }, 500);
+                }
+              });
+          },
+        );
       }
     });
 
     if (webviewView.visible) {
       this.updateWebviewHtml();
       setTimeout(() => {
-        getControlPlaneEnv(this.ide.getIdeSettings()).then((controlPlaneEnv) => {
-          vscode.authentication.getSession(
-            controlPlaneEnv.AUTH_TYPE,
-            [],
-            { silent: true },
-          ).then((session) => {
-            if (!session) {
-              console.log("初始化时未登录，自动触发登录...");
-              webviewView.webview.postMessage({ command: "triggerLogin" });
-            }
-          });
-        });
+        getControlPlaneEnv(this.ide.getIdeSettings()).then(
+          (controlPlaneEnv) => {
+            vscode.authentication
+              .getSession(controlPlaneEnv.AUTH_TYPE, [], { silent: true })
+              .then((session) => {
+                if (!session) {
+                  console.log("初始化时未登录，自动触发登录...");
+                  webviewView.webview.postMessage({ command: "triggerLogin" });
+                }
+              });
+          },
+        );
       }, 1000);
     }
-
-
   }
 
   /**
    * 根据登录状态更新 Webview 的 HTML 内容
    */
-  private async updateWebviewHtml() {
+  private async updateWebviewHtml(force = false) {
     if (!this._webviewView) {
       return;
     }
@@ -149,7 +161,12 @@ export class ContinueGUIWebviewViewProvider
       { silent: true },
     );
 
-    if (session) {
+    const nextView: "app" | "login" = session ? "app" : "login";
+    if (!force && this._lastRenderedView === nextView) {
+      return;
+    }
+
+    if (nextView === "app") {
       // 已登录：显示主页面（React 应用）
       this._webviewView.webview.html = this.getSidebarContent(
         this.extensionContext,
@@ -157,8 +174,11 @@ export class ContinueGUIWebviewViewProvider
       );
     } else {
       // 未登录：显示登录引导页
-      this._webviewView.webview.html = this.getLoginRequiredContent(this._webviewView.webview);
+      this._webviewView.webview.html = this.getLoginRequiredContent(
+        this._webviewView.webview,
+      );
     }
+    this._lastRenderedView = nextView;
   }
 
   /**
@@ -171,7 +191,7 @@ export class ContinueGUIWebviewViewProvider
   private getLoginRequiredContent(webview: vscode.Webview): string {
     const extensionUri = this.extensionContext.extensionUri;
     const logoUri = webview.asWebviewUri(
-      vscode.Uri.joinPath(extensionUri, "media", "icon.png")
+      vscode.Uri.joinPath(extensionUri, "media", "icon.png"),
     );
 
     const nonce = getNonce();
@@ -292,7 +312,7 @@ export class ContinueGUIWebviewViewProvider
                     btn.disabled = false;
                     progress.innerText = '如果浏览器未打开，请点击重新登录';
                   }
-                }, 60000); // 缩短超时提示 1分钟
+                }, 30000); // 缩短超时提示 30秒
               } catch (err) {
                 console.error("处理出错:", err);
               }

--- a/extensions/vscode/src/VsCodeIde.ts
+++ b/extensions/vscode/src/VsCodeIde.ts
@@ -352,7 +352,7 @@ class VsCodeIde implements IDE {
       terminal = vscode.window.createTerminal(options?.terminalName);
     }
     terminal.show();
-    terminal.sendText(command, false);
+    terminal.sendText(command, true);
   }
 
   async saveFile(fileUri: string): Promise<void> {

--- a/extensions/vscode/src/stubs/WorkOsAuthProvider.ts
+++ b/extensions/vscode/src/stubs/WorkOsAuthProvider.ts
@@ -21,7 +21,6 @@ import {
   Event,
   EventEmitter,
   ExtensionContext,
-  ProgressLocation,
   Uri,
   window,
 } from "vscode";
@@ -108,17 +107,14 @@ export class WorkOsAuthProvider implements AuthenticationProvider, Disposable {
 
     this.secretStorage = new SecretStorage(context);
 
-    // Immediately refresh any existing sessions
+    // Initialize refresh-attempt gate for downstream flows
     this.attemptEmitter = new NodeEventEmitter();
     WorkOsAuthProvider.hasAttemptedRefresh = new Promise((resolve) => {
       this.attemptEmitter.on("attempted", resolve);
     });
-    void this.refreshSessions();
 
-    // Set up a regular interval to refresh tokens
-    this._refreshInterval = setInterval(() => {
-      void this.refreshSessions();
-    }, WorkOsAuthProvider.REFRESH_INTERVAL_MS);
+    // Disable session auto-refresh: immediately unblock dependent flows
+    this.attemptEmitter.emit("attempted");
   }
 
   private decodeJwt(jwt: string): Record<string, any> | null {
@@ -235,25 +231,9 @@ export class WorkOsAuthProvider implements AuthenticationProvider, Disposable {
   public static hasAttemptedRefresh: Promise<void>;
   private attemptEmitter: NodeEventEmitter;
   async refreshSessions() {
-    // Prevent concurrent refresh operations
-    if (this._isRefreshing) {
-      return;
-    }
-
-    try {
-      this._isRefreshing = true;
-      await this._refreshSessions();
-    } catch (e) {
-      // Capture session refresh failures to Sentry
-      Logger.error(e, {
-        context: "workOS_auth_session_refresh",
-        authType: controlPlaneEnv.AUTH_TYPE,
-      });
-
-      console.error(`Error refreshing sessions: ${e}`);
-    } finally {
-      this._isRefreshing = false;
-    }
+    // Disable session refresh, only signal that refresh has been attempted.
+    this.attemptEmitter.emit("attempted");
+    return;
   }
 
   // It is important that every path in this function emits the attempted event
@@ -338,7 +318,7 @@ export class WorkOsAuthProvider implements AuthenticationProvider, Disposable {
       // Calculate exponential backoff delay with jitter
       const delay = Math.min(
         baseDelay * Math.pow(2, attempt - 1) * (0.5 + Math.random() * 0.5),
-        1 * 60 * 1000, // 1 minutes
+        0.5 * 60 * 1000, // 0.5 minutes
       );
 
       return new Promise((resolve, reject) => {
@@ -511,9 +491,11 @@ export class WorkOsAuthProvider implements AuthenticationProvider, Disposable {
     console.log("AuthProvider: 准备构造 stateId:", stateId);
     const url = new URL(loginUrl);
     const params = {
-        siteCode: Buffer.from(authConfig.SITE_CODE).toString("base64"),
-        app: Buffer.from(authConfig.SITE_NAME).toString("base64"),
-        callBackUrl: Buffer.from(`${this.redirectUri}?state=${stateId}`).toString("base64"),
+      siteCode: Buffer.from(authConfig.SITE_CODE).toString("base64"),
+      app: Buffer.from(authConfig.SITE_NAME).toString("base64"),
+      callBackUrl: Buffer.from(`${this.redirectUri}?state=${stateId}`).toString(
+        "base64",
+      ),
     };
 
     Object.keys(params).forEach((key) =>
@@ -522,17 +504,22 @@ export class WorkOsAuthProvider implements AuthenticationProvider, Disposable {
 
     const oauthUrl = url;
     if (oauthUrl) {
-      console.log(`AuthProvider: 准备调用 env.openExternal: ${oauthUrl.toString()}`);
+      console.log(
+        `AuthProvider: 准备调用 env.openExternal: ${oauthUrl.toString()}`,
+      );
       // 使用异步不阻塞的方式打开链接，避免因为用户未授权导致整个登录流死锁
-      env.openExternal(Uri.parse(oauthUrl.toString())).then((success) => {
-        if (!success) {
-          console.error("AuthProvider: 打开外部链接失败");
-        } else {
-          console.log("AuthProvider: 外部链接已触发打开");
-        }
-      }).catch(err => {
-        console.error("AuthProvider: 调用 env.openExternal 抛出异常", err);
-      });
+      env
+        .openExternal(Uri.parse(oauthUrl.toString()))
+        .then((success) => {
+          if (!success) {
+            console.error("AuthProvider: 打开外部链接失败");
+          } else {
+            console.log("AuthProvider: 外部链接已触发打开");
+          }
+        })
+        .catch((err) => {
+          console.error("AuthProvider: 调用 env.openExternal 抛出异常", err);
+        });
     } else {
       console.log("AuthProvider: oauthUrl 为空，直接返回");
       return;
@@ -562,11 +549,11 @@ export class WorkOsAuthProvider implements AuthenticationProvider, Disposable {
       }
       this._codeExchangePromises.set(scopeString, codeExchangePromise);
     } else {
-       console.log("AuthProvider: 发现旧的 Promise 残留，先取消它");
-       codeExchangePromise.cancel.fire();
-       this._codeExchangePromises.delete(scopeString);
+      console.log("AuthProvider: 发现旧的 Promise 残留，先取消它");
+      codeExchangePromise.cancel.fire();
+      this._codeExchangePromises.delete(scopeString);
 
-       if (this._localLoginServer) {
+      if (this._localLoginServer) {
         codeExchangePromise = promiseFromEvent(
           this._localLoginServer.onCodeReceived,
           async (data, resolve, reject) => {
@@ -592,14 +579,15 @@ export class WorkOsAuthProvider implements AuthenticationProvider, Disposable {
         codeExchangePromise.promise,
         new Promise<string>(
           (_, reject) =>
-            setTimeout(() => reject(new Error("Login Cancelled by timeout")), 1 * 60 * 1000), // 1min timeout
+            setTimeout(
+              () => reject(new Error("Login Cancelled by timeout")),
+              0.5 * 60 * 1000,
+            ), // 0.5min timeout
         ),
       ]);
     } finally {
       console.log("AuthProvider: Promise.race 结束，清理状态");
-      this._pendingStates = this._pendingStates.filter(
-        (n) => n !== stateId,
-      );
+      this._pendingStates = this._pendingStates.filter((n) => n !== stateId);
       codeExchangePromise?.cancel.fire();
       this._codeExchangePromises.delete(scopeString);
     }
@@ -653,21 +641,20 @@ export class WorkOsAuthProvider implements AuthenticationProvider, Disposable {
         ccid: "123456789",
         userName: "developer",
         deptName: "test",
-        access_token: "sim_access_token_" + Math.random().toString(36).substring(7),
-        refresh_token: "sim_refresh_token_" + Math.random().toString(36).substring(7),
+        access_token:
+          "sim_access_token_" + Math.random().toString(36).substring(7),
+        refresh_token:
+          "sim_refresh_token_" + Math.random().toString(36).substring(7),
       };
     }
 
     const userInfoBaseUrl = hubEnv.customAuthConfig.USER_INFO_URL;
-    const resp = await fetch(
-      `${userInfoBaseUrl}${token}`,
-      {
-        method: "get",
-        headers: {
-          "Content-Type": "application/json",
-        }
+    const resp = await fetch(`${userInfoBaseUrl}${token}`, {
+      method: "get",
+      headers: {
+        "Content-Type": "application/json",
       },
-    );
+    });
     const text = await resp.text();
     const res = JSON.parse(text);
     const data = JSON.parse(res.data);

--- a/gui/src/components/Layout.tsx
+++ b/gui/src/components/Layout.tsx
@@ -142,7 +142,7 @@ const Layout = () => {
   useWebviewListener(
     "setupLocalConfig",
     async () => {
-      onboardingCard.open(OnboardingModes.LOCAL);
+      // onboardingCard.open(OnboardingModes.LOCAL);
     },
     [],
   );
@@ -150,15 +150,15 @@ const Layout = () => {
   useWebviewListener(
     "freeTrialExceeded",
     async () => {
-      dispatch(setShowDialog(true));
-      onboardingCard.setActiveTab(OnboardingModes.MODELS_ADD_ON);
-      dispatch(
-        setDialogMessage(
-          <div className="flex-1">
-            <OnboardingCard isDialog />
-          </div>,
-        ),
-      );
+      // dispatch(setShowDialog(true));
+      // onboardingCard.setActiveTab(OnboardingModes.MODELS_ADD_ON);
+      // dispatch(
+      //   setDialogMessage(
+      //     <div className="flex-1">
+      //       <OnboardingCard isDialog />
+      //     </div>,
+      //   ),
+      // );
     },
     [],
   );
@@ -166,7 +166,7 @@ const Layout = () => {
   useWebviewListener(
     "setupApiKey",
     async () => {
-      onboardingCard.open(OnboardingModes.API_KEY);
+      // onboardingCard.open(OnboardingModes.API_KEY);
     },
     [],
   );
@@ -231,7 +231,7 @@ const Layout = () => {
 
   useEffect(() => {
     if (isNewUserOnboarding() && isHome) {
-      onboardingCard.open();
+      // onboardingCard.open();
     }
   }, [isHome]);
 

--- a/gui/src/context/Auth.tsx
+++ b/gui/src/context/Auth.tsx
@@ -23,6 +23,8 @@ import { IdeMessengerContext } from "./IdeMessenger";
 
 interface AuthContextType {
   session: ControlPlaneSessionInfo | undefined;
+  isSessionLoading: boolean;
+  hasCachedSession: boolean;
   logout: () => void;
   login: (useOnboarding: boolean) => Promise<boolean>;
   selectedProfile: ProfileDescription | null;
@@ -32,6 +34,7 @@ interface AuthContextType {
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
+const AUTH_SESSION_CACHE_KEY = "continue.auth.hasSession";
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
@@ -42,6 +45,14 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   const [session, setSession] = useState<ControlPlaneSessionInfo | undefined>(
     undefined,
   );
+  const [isSessionLoading, setIsSessionLoading] = useState(true);
+  const [hasCachedSession, setHasCachedSession] = useState<boolean>(() => {
+    try {
+      return window.localStorage.getItem(AUTH_SESSION_CACHE_KEY) === "1";
+    } catch {
+      return false;
+    }
+  });
 
   // Orgs
   const orgs = useAppSelector((store) => store.profiles.organizations);
@@ -50,7 +61,21 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   const currentOrg = useAppSelector(selectCurrentOrg);
   const selectedProfile = useAppSelector(selectSelectedProfile);
 
+  const setSessionCache = (hasSession: boolean) => {
+    setHasCachedSession(hasSession);
+    try {
+      if (hasSession) {
+        window.localStorage.setItem(AUTH_SESSION_CACHE_KEY, "1");
+      } else {
+        window.localStorage.removeItem(AUTH_SESSION_CACHE_KEY);
+      }
+    } catch {
+      // ignore persistence failures
+    }
+  };
+
   const login: AuthContextType["login"] = async (useOnboarding: boolean) => {
+    setIsSessionLoading(true);
     try {
       const result = await ideMessenger.request("getControlPlaneSessionInfo", {
         silent: false,
@@ -59,17 +84,20 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
 
       if (result.status === "error") {
         console.error("Login failed:", result.error);
+        setSession(undefined);
+        setSessionCache(false);
         return false;
       }
 
       const session = result.content;
       setSession(session);
-
-      return true;
+      setSessionCache(Boolean(session));
+      return Boolean(session);
     } catch (error: any) {
       console.error("Login request failed:", error);
-      // Let the error propagate so the caller can handle it
       throw error;
+    } finally {
+      setIsSessionLoading(false);
     }
   };
 
@@ -78,25 +106,44 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     dispatch(setOrganizations(orgs.filter((org) => org.id === "personal")));
     dispatch(setSelectedOrgId("personal"));
     setSession(undefined);
+    setSessionCache(false);
+    setIsSessionLoading(false);
   };
 
   useEffect(() => {
     async function init() {
-      const result = await ideMessenger.request("getControlPlaneSessionInfo", {
-        silent: true,
-        useOnboarding: false,
-      });
-      if (result.status === "success") {
-        setSession(result.content);
+      setIsSessionLoading(true);
+      try {
+        const result = await ideMessenger.request(
+          "getControlPlaneSessionInfo",
+          {
+            silent: true,
+            useOnboarding: false,
+          },
+        );
+        if (result.status === "success") {
+          setSession(result.content);
+          setSessionCache(Boolean(result.content));
+        } else {
+          setSession(undefined);
+          setSessionCache(false);
+        }
+      } catch {
+        setSession(undefined);
+        setSessionCache(false);
+      } finally {
+        setIsSessionLoading(false);
       }
     }
     void init();
-  }, []);
+  }, [ideMessenger]);
 
   useWebviewListener(
     "sessionUpdate",
     async (data) => {
       setSession(data.sessionInfo);
+      setSessionCache(Boolean(data.sessionInfo));
+      setIsSessionLoading(false);
     },
     [],
   );
@@ -123,6 +170,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     <AuthContext.Provider
       value={{
         session,
+        isSessionLoading,
+        hasCachedSession,
         logout,
         login,
         selectedProfile,

--- a/gui/src/index.css
+++ b/gui/src/index.css
@@ -62,6 +62,39 @@ body {
   }
 }
 
+@keyframes authPulse {
+  0% {
+    opacity: 0.45;
+  }
+  50% {
+    opacity: 0.9;
+  }
+  100% {
+    opacity: 0.45;
+  }
+}
+
+.auth-transition-enter {
+  animation: fadeIn 0.16s ease-out;
+}
+
+.auth-loading-shell {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+
+.auth-loading-bar {
+  width: 120px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--vscode-progressBar-background, #3b82f6);
+  animation: authPulse 1s ease-in-out infinite;
+}
+
 .fade-in-span {
   animation: fadeIn 0.3s ease-in-out;
 }

--- a/gui/src/pages/Login/Login.module.css
+++ b/gui/src/pages/Login/Login.module.css
@@ -5,10 +5,14 @@
   flex-direction: column;
   align-items: center;
   justify-content: space-between;
-  background-color: #f5f5f5;
+  background-color: var(--vscode-sideBar-background);
+  color: var(--vscode-sideBar-foreground);
   overflow-y: hidden;
   position: relative;
   box-sizing: border-box;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
 }
 
 .logoWrapper {
@@ -49,7 +53,7 @@
 .description {
   font-size: 18px;
   line-height: 1.5;
-  color: #333;
+  color: var(--vscode-sideBar-foreground);
   text-align: center;
   margin: 0;
 }
@@ -71,8 +75,8 @@
   width: 80%;
   max-width: 400px;
   height: 48px;
-  background-color: #2563eb;
-  color: #fff;
+  background-color: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
   border: none;
   border-radius: 6px;
   font-size: 16px;
@@ -81,16 +85,16 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background-color 0.3s ease;
+  transition: background-color 0.2s ease;
 }
 
 .loginButton:disabled {
-  background-color: #93c5fd;
+  opacity: 0.7;
   cursor: not-allowed;
 }
 
 .loginButton:hover:not(:disabled) {
-  background-color: #1d4ed8;
+  background-color: var(--vscode-button-hoverBackground);
 }
 
 .spinner {


### PR DESCRIPTION
# 终端命令执行自动停止优化 (2026-05-09)

## 修改说明

本文档记录了解决 VS Code 插件终端执行命令无法自动停止的问题，涉及命令发送机制及 Windows 下的进程销毁优化。

### 修改 A：确保终端命令完整触发执行

- **修改点**: 在 `VsCodeIde.ts` 的 `runCommand` 方法中，将 `terminal.sendText(command, false)` 修改为 `terminal.sendText(command, true)`。
- **原理**: 第二个参数 `addNewLine` 设为 `true` 会在命令末尾自动添加换行符。此前为 `false` 导致命令发送到终端后未能触发回车执行，终端一直处于等待输入状态，给用户造成“未停止”或“卡住”的错觉。
- **文件**: [VsCodeIde.ts](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/extensions/vscode/src/VsCodeIde.ts)

### 修改 B：优化 Windows 下的子进程树清理

- **修改点**: 在 `processTerminalStates.ts` 的 `killTerminalProcess` 函数中，针对 Windows 平台引入 `taskkill` 命令。
- **具体逻辑**:
  - Windows: 使用 `taskkill /pid ${childProc.pid} /T /F` 强制杀死进程及其所有子进程（进程树）。
  - 非 Windows: 维持原有的 `SIGTERM` 并在 5 秒后追加 `SIGKILL` 的逻辑。
- **原理**: 在 Windows 上，标准的 `childProc.kill()` 往往只能杀死外壳进程（如 `powershell.exe`），而无法清理其派生的实际任务进程（如 `node.exe`）。使用 `/T` 参数可确保整个进程树被彻底清理，从而实现真正的“自动停止”。
- **文件**: [processTerminalStates.ts](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/core/util/processTerminalStates.ts)

---

**相关文件**:

- [VsCodeIde.ts](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/extensions/vscode/src/VsCodeIde.ts)
- [processTerminalStates.ts](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/core/util/processTerminalStates.ts)

---

# 已登录状态下插件切换返回登录页闪现修复 (2026-05-09)

## 修改说明

本文档补充记录了“用户已登录时，从其他插件切回 Continue 出现登录页短暂闪现”的问题修复。修复覆盖认证状态管理、Webview 生命周期、页面过渡与回归测试。

### 修改 C：认证状态初始化显式化，避免首帧误判未登录

- **修改点**: 在 `Auth.tsx` 中新增 `isSessionLoading` 与 `hasCachedSession`，并引入 `continue.auth.hasSession` 本地持久化标记。
- **具体逻辑**:
  - 启动阶段先进入 `isSessionLoading=true`，异步拉取会话后再决定渲染登录页或主界面。
  - 登录成功、`sessionUpdate`、退出登录时同步更新本地缓存标记。
  - `login` 与初始化流程统一维护 `isSessionLoading`，不再用 `session===undefined` 同时表示“初始化中”和“未登录”。
- **原理**: 将“状态未完成”与“未认证”解耦，消除初始化窗口内的错误分支渲染，从根源上避免登录页闪现。
- **文件**: [Auth.tsx](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/gui/src/context/Auth.tsx)

### 修改 D：布局层增加认证加载占位与轻量过渡

- **修改点**: 在 `Layout.tsx` 中增加认证加载占位分支；在会话加载期间不渲染 `Login`，而是渲染占位壳。
- **具体逻辑**:
  - `isSessionLoading` 时显示占位（`auth-loading-placeholder`）。
  - 已加载且无 session 才展示登录页。
  - 已加载且有 session 进入主页面。
  - 主容器与登录容器增加 `auth-transition-enter` 淡入类。
- **原理**: 避免“先登录页后主界面”的闪烁切换，改为可控的加载态过渡。
- **文件**: [Layout.tsx](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/gui/src/components/Layout.tsx)

### 修改 E：补充认证切换动画样式

- **修改点**: 在 `index.css` 中新增 `.auth-transition-enter`、`.auth-loading-shell`、`.auth-loading-bar` 与 `@keyframes authPulse`。
- **原理**: 通过短时淡入与低成本脉冲占位降低视觉抖动，提升切换感知流畅度。
- **文件**: [index.css](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/gui/src/index.css)

### 修改 F：Webview 生命周期去重，避免重复重挂载

- **修改点**: 在 `ContinueGUIWebviewViewProvider.ts` 中新增 `_lastRenderedView`，并将 `updateWebviewHtml()` 改为 `updateWebviewHtml(force = false)`。
- **具体逻辑**:
  - 每次检查会话后计算目标视图 `app/login`。
  - 若目标视图与上次一致且非强制刷新，则跳过 `webview.html` 重写。
  - 登录成功路径使用 `force=true` 立即切换。
- **原理**: 避免插件切换可见性变化时反复重写同态 HTML，减少 React 重挂载与首帧抖动机会。
- **文件**: [ContinueGUIWebviewViewProvider.ts](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/extensions/vscode/src/ContinueGUIWebviewViewProvider.ts)

### 修改 G：新增回归测试覆盖闪现场景

- **修改点**: 新增 `Layout.auth.test.tsx`，覆盖两个关键场景：
  - 已登录：初始化阶段仅出现占位，不出现登录按钮；
  - 未登录：初始化完成后进入登录页，缓存标记正确清理。
- **原理**: 通过测试固定“初始化加载态优先于登录页渲染”的行为，防止后续回归。
- **文件**: [Layout.auth.test.tsx](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/gui/src/components/Layout.auth.test.tsx)

## 验证结果

- **静态检查**: 相关改动文件诊断通过（无新增 TS/ESLint 报错）。
- **测试命令**: `npm run test -- src/components/Layout.auth.test.tsx`（目录 `gui`）。
- **结果**: 2 个测试均通过，exit code 0。

---

# 登录会话不自动刷新 (2026-05-09)

## 修改说明

本文档补充记录“禁用登录会话自动刷新”的改动，目标是让插件不再周期性调用刷新接口续期会话。

### 修改 H：禁用启动阶段与定时器刷新

- **修改点**: 在 `WorkOsAuthProvider` 构造函数中移除 `void this.refreshSessions()` 与 `setInterval(...REFRESH_INTERVAL_MS)`。
- **具体逻辑**:
  - 保留 `hasAttemptedRefresh` 的初始化；
  - 通过 `this.attemptEmitter.emit("attempted")` 立即释放依赖等待，避免下游流程被阻塞；
  - 不再注册周期性刷新任务。
- **原理**: 关闭自动续期入口，避免插件在后台定时发起 token 刷新请求。
- **文件**: [WorkOsAuthProvider.ts](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/extensions/vscode/src/stubs/WorkOsAuthProvider.ts)

### 修改 I：将 `refreshSessions()` 改为 no-op

- **修改点**: 重写 `refreshSessions()` 方法，不再执行 `_refreshSessions()` 与网络刷新逻辑。
- **具体逻辑**:
  - 方法仅保留 `this.attemptEmitter.emit("attempted")`；
  - 不再进入并发保护、错误上报与刷新流程。
- **原理**: 即使外部路径仍调用该方法，也不会触发实际会话刷新。
- **文件**: [WorkOsAuthProvider.ts](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/extensions/vscode/src/stubs/WorkOsAuthProvider.ts)

## 验证结果

- **静态检查**: [WorkOsAuthProvider.ts](file:///d:/cai/vscode%E6%8F%92%E4%BB%B6/continue-cai/extensions/vscode/src/stubs/WorkOsAuthProvider.ts) 诊断通过（无新增错误）。

## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
