### PR TITLE
feat: 优化私有化登录流程、SSL校验及终端安全策略，并完善相关文档

### DIFF
--- a/core/tools/definitions/runTerminalCommand.ts
+++ b/core/tools/definitions/runTerminalCommand.ts
@@ -1,30 +1,41 @@
-import os from "os";
-import { Tool } from "../..";
-import { BUILT_IN_GROUP_NAME, BuiltInToolNames } from "../builtIn";
 import {
   evaluateTerminalCommandSecurity,
   ToolPolicy,
-} from "@continuedev/terminal-security";
+} from "@continuedev/terminal-security"; // 导入终端命令安全评估工具和策略类型
+import os from "os"; // 导入 Node.js 的 os 模块，用于获取操作系统信息
+import { Tool } from "../.."; // 导入 Tool 类型定义，用于定义工具接口
+import { BUILT_IN_GROUP_NAME, BuiltInToolNames } from "../builtIn"; // 导入内置工具组名称和内置工具枚举名
 
 /**
- * Get the preferred shell for the current platform
- * @returns The preferred shell command or path
+ * 获取当前平台的首选 Shell
+ * @returns 首选的 Shell 命令或路径
  */
 function getPreferredShell(): string {
-  const platform = os.platform();
+  const platform = os.platform(); // 获取当前操作系统平台
 
   if (platform === "win32") {
-    return "powershell.exe";
+    return "powershell.exe"; // Windows 平台使用 powershell
   } else if (platform === "darwin") {
-    return process.env.SHELL || "/bin/zsh";
+    return process.env.SHELL || "/bin/zsh"; // macOS 优先使用环境变量 SHELL，默认为 zsh
   } else {
-    // Linux and other Unix-like systems
-    return process.env.SHELL || "/bin/bash";
+    // Linux 及其他类 Unix 系统
+    return process.env.SHELL || "/bin/bash"; // 优先使用环境变量 SHELL，默认为 bash
   }
 }
 
+/**
+ * 平台信息字符串：根据操作系统、架构和 Shell 提供优化的建议
+ */
 const PLATFORM_INFO = `Choose terminal commands and scripts optimized for ${os.platform()} and ${os.arch()} and shell ${getPreferredShell()}.`;
 
+/**
+ * 运行命令的注意事项：
+ * 1. Shell 是无状态的，不会记忆之前的命令。
+ * 2. 运行后台命令时，务必建议使用 Shell 命令停止；严禁建议使用 Ctrl+C。
+ * 3. 建议后续 Shell 命令时，务必使用 Shell 代码块格式。
+ * 4. 不要执行需要特殊或管理员权限的操作。
+ * 5. 重要：修改文件时，请使用 Edit/MultiEdit 工具，不要使用 bash 命令（如 sed, awk 等）。
+ */
 const RUN_COMMAND_NOTES = `The shell is not stateful and will not remember any previous commands.\
       When a command is run in the background ALWAYS suggest using shell commands to stop it; NEVER suggest using Ctrl+C.\
       When suggesting subsequent shell commands ALWAYS format them in shell command blocks.\
@@ -32,49 +43,69 @@ const RUN_COMMAND_NOTES = `The shell is not stateful and will not remember any p
       IMPORTANT: To edit files, use Edit/MultiEdit tools instead of bash commands (sed, awk, etc).\
       ${PLATFORM_INFO}`;
 
+/**
+ * 终端命令执行工具定义
+ */
 export const runTerminalCommandTool: Tool = {
   type: "function",
-  displayTitle: "Run Terminal Command",
-  wouldLikeTo: "run the following terminal command:",
-  isCurrently: "running the following terminal command:",
-  hasAlready: "ran the following terminal command:",
-  readonly: false,
-  group: BUILT_IN_GROUP_NAME,
+  displayTitle: "Run Terminal Command", // IDE 中显示的标题
+  wouldLikeTo: "run the following terminal command:", // 意图引导语
+  isCurrently: "running the following terminal command:", // 正在执行时的状态语
+  hasAlready: "ran the following terminal command:", // 执行完成后的状态语
+  readonly: false, // 标识该工具是否为只读
+  group: BUILT_IN_GROUP_NAME, // 工具所属的分组
   function: {
-    name: BuiltInToolNames.RunTerminalCommand,
-    description: `Run a terminal command in the current directory.\n${RUN_COMMAND_NOTES}`,
+    name: BuiltInToolNames.RunTerminalCommand, // 工具函数的名称
+    description: `Run a terminal command in the current directory.\n${RUN_COMMAND_NOTES}`, // 工具函数的描述
     parameters: {
       type: "object",
-      required: ["command"],
+      required: ["command"], // 必填参数列表
       properties: {
         command: {
           type: "string",
           description:
-            "The command to run. This will be passed directly into the IDE shell.",
+            "The command to run. This will be passed directly into the IDE shell.", // 参数描述：要执行的命令字符串
         },
         waitForCompletion: {
           type: "boolean",
           description:
-            "Whether to wait for the command to complete before returning. Default is true. Set to false to run the command in the background. Set to true to run the command in the foreground and wait to collect the output.",
+            "Whether to wait for the command to complete before returning. Default is true. Set to false to run the command in the background. Set to true to run the command in the foreground and wait to collect the output.", // 参数描述：是否等待命令执行完成。默认 true（前台执行并获取输出），false 则为后台执行。
         },
       },
     },
   },
-  defaultToolPolicy: "allowedWithPermission",
+  defaultToolPolicy: "allowedWithPermission", // 默认工具策略：需要权限才能执行
+  /**
+   * 评估工具调用的安全性策略
+   * @param basePolicy 基础策略
+   * @param parsedArgs 解析后的参数对象
+   * @returns 经过安全评估后的最终策略
+   */
   evaluateToolCallPolicy: (
     basePolicy: ToolPolicy,
     parsedArgs: Record<string, unknown>,
   ): ToolPolicy => {
-    return evaluateTerminalCommandSecurity(
+    const securityResult = evaluateTerminalCommandSecurity(
       basePolicy,
       parsedArgs.command as string,
     );
+
+    // 如果安全评估为禁用，则改为需要人工确认
+    if (securityResult === "disabled") {
+      return "allowedWithPermission";
+    }
+
+    // 其他情况（包括高风险命令被提升的情况）一律遵循用户设置的基础策略
+    return basePolicy;
   },
+  /**
+   * 系统消息描述，用于指导模型如何使用该工具
+   */
   systemMessageDescription: {
     prefix: `To run a terminal command, use the ${BuiltInToolNames.RunTerminalCommand} tool
 ${RUN_COMMAND_NOTES}
 You can also optionally include the waitForCompletion argument set to false to run the command in the background.      
-For example, to see the git log, you could respond with:`,
-    exampleArgs: [["command", "git log"]],
+For example, to see the git log, you could respond with:`, // 指导语前缀
+    exampleArgs: [["command", "git log"]], // 使用示例
   },
 };

--- a/extensions/vscode/src/ContinueGUIWebviewViewProvider.ts
+++ b/extensions/vscode/src/ContinueGUIWebviewViewProvider.ts
@@ -1,20 +1,40 @@
+// 导入 VS Code 核心 API
 import * as vscode from "vscode";
 
+// 导入控制面环境配置工具
 import { getControlPlaneEnv } from "core/control-plane/env";
+// 导入获取主题的工具函数
 import { getTheme } from "./util/getTheme";
+// 导入获取版本和 URI 协议方案的工具函数
 import { getExtensionVersion, getvsCodeUriScheme } from "./util/util";
+// 导入 VS Code 相关的基础工具函数
 import { getExtensionUri, getNonce, getUniqueId } from "./util/vscode";
+// 导入 VS Code IDE 实现类
 import { VsCodeIde } from "./VsCodeIde";
+// 导入 Webview 通讯协议类
 import { VsCodeWebviewProtocol } from "./webviewProtocol";
 
+// 导入核心逻辑中的文件编辑类型定义
 import type { FileEdit } from "core";
 
+/**
+ * Continue 主界面的 Webview 视图提供者
+ * 负责在侧边栏渲染 React 应用，并处理与插件后端的通讯
+ */
 export class ContinueGUIWebviewViewProvider
   implements vscode.WebviewViewProvider
 {
+  // 视图 ID，需与 package.json 中的一致
   public static readonly viewType = "continue.continueGUIView";
+  // 专门用于 Webview 通讯的协议实例
   public webviewProtocol: VsCodeWebviewProtocol;
 
+  /**
+   * 构造函数
+   * @param windowId 窗口唯一 ID
+   * @param extensionContext 扩展上下文
+   * @param ide IDE 接口实例
+   */
   constructor(
     private readonly windowId: string,
     private readonly extensionContext: vscode.ExtensionContext,
@@ -23,24 +43,29 @@ export class ContinueGUIWebviewViewProvider
     this.webviewProtocol = new VsCodeWebviewProtocol();
   }
 
+  /**
+   * VS Code 激活 Webview 时的回调方法
+   */
   resolveWebviewView(
     webviewView: vscode.WebviewView,
     _context: vscode.WebviewViewResolveContext,
     _token: vscode.CancellationToken,
   ): void | Thenable<void> {
-    // 允许执行脚本，否则登录按钮点击没反应
+    // 配置 Webview 选项：允许脚本执行，限制资源访问范围
     webviewView.webview.options = {
       enableScripts: true,
       localResourceRoots: [this.extensionContext.extensionUri],
     };
 
+    // 绑定协议实例到当前的 Webview
     this.webviewProtocol.webview = webviewView.webview;
     this._webviewView = webviewView;
     this._webview = webviewView.webview;
 
-    // 处理来自登录引导页的消息
-    // 原理：监听 Webview 发送的简单 command 消息。当用户点击自定义 HTML 中的登录按钮时，
-    // 发送 { command: "login" }，由扩展后台捕获并启动标准的 VS Code 身份验证流程。
+    /**
+     * 处理来自 Webview 的原生消息
+     * 主要用于处理登录逻辑，因为登录按钮可能在 React 挂载前的 HTML 中
+     */
     webviewView.webview.onDidReceiveMessage(async (data) => {
       console.log("ContinueGUIWebviewViewProvider: 收到 Webview 消息:", data);
       const command = data.command || data.messageType;
@@ -57,7 +82,7 @@ export class ContinueGUIWebviewViewProvider
           );
 
           // 核心原理：调用 VS Code 的身份验证 API，触发 OAuth 流程
-          // 强制触发新的 Session，无视可能挂起的缓存
+          // 使用 forceNewSession: true 确保每次点击都重新发起授权
           const session = await vscode.authentication.getSession(
             controlPlaneEnv.AUTH_TYPE,
             [],
@@ -69,56 +94,59 @@ export class ContinueGUIWebviewViewProvider
             void vscode.window.showInformationMessage(
               "登录成功: " + session.account.label,
             );
-            // 登录成功后同步 Session 状态
+            // 登录成功后，主动通知前端同步 Session 状态
             this.syncSession();
           } else {
             console.warn("未获取到 Session，可能用户取消了登录");
-            // 通知前端登录失败，重置按钮状态
-            webviewView.webview.postMessage({ command: "loginFailed" });
+            // 通知前端登录失败，以便重置 UI 状态
+            // webviewView.webview.postMessage({ command: "loginFailed" });
           }
         } catch (err: any) {
           console.error("登录出错:", err);
-          // 通知前端登录失败，重置按钮状态
+          // 通知前端登录失败
           webviewView.webview.postMessage({ command: "loginFailed" });
         }
       }
     });
 
-    // 初始化时直接加载 React 应用
+    // 生成并设置 Webview 的初始 HTML（即加载 React 的容器）
     this._webviewView.webview.html = this.getSidebarContent(
       this.extensionContext,
       this._webviewView,
     );
 
-    // 监听登录状态变化
+    /**
+     * 监听 VS Code 全局登录状态变化
+     * 当用户在外部（如浏览器）完成登录后，此处会被触发
+     */
     const authSubscription = vscode.authentication.onDidChangeSessions(
       async (e) => {
         const controlPlaneEnv = await getControlPlaneEnv(
           this.ide.getIdeSettings(),
         );
         if (e.provider.id === controlPlaneEnv.AUTH_TYPE) {
-          // 状态变化时同步 Session，而不是重新加载 HTML
+          // 状态变化时同步 Session，确保前端 UI 及时更新
           this.syncSession();
         }
       },
     );
     this.extensionContext.subscriptions.push(authSubscription);
 
-    // 当 Webview 变得可见时，尝试同步 Session
+    // 当用户切回侧边栏，视图重新可见时，自动检查并同步登录状态
     webviewView.onDidChangeVisibility(() => {
       if (webviewView.visible) {
         this.syncSession();
       }
     });
 
-    // 初始化时也同步一次
+    // 初始化延迟同步，确保 Webview 已经准备好接收消息
     if (webviewView.visible) {
       setTimeout(() => this.syncSession(), 1000);
     }
   }
 
   /**
-   * 同步当前 VS Code 的登录 Session 到 Webview
+   * 将 VS Code 的登录 Session 状态推送给前端 React 应用
    */
   private async syncSession() {
     if (!this._webviewView) {
@@ -129,6 +157,7 @@ export class ContinueGUIWebviewViewProvider
       const controlPlaneEnv = await getControlPlaneEnv(
         this.ide.getIdeSettings(),
       );
+      // 获取当前 Session（silent: true 表示静默获取，不弹出登录框）
       const session = await vscode.authentication.getSession(
         controlPlaneEnv.AUTH_TYPE,
         [],
@@ -136,7 +165,7 @@ export class ContinueGUIWebviewViewProvider
       );
 
       if (session) {
-        // 通过协议或直接 postMessage 发送 Session 信息
+        // 向前端发送最新的用户信息
         this._webviewView.webview.postMessage({
           messageType: "sessionUpdate",
           data: {
@@ -150,7 +179,7 @@ export class ContinueGUIWebviewViewProvider
           },
         });
       } else {
-        // 如果没有 Session，也发送通知以便前端清除状态
+        // 如果没有有效 Session，通知前端清除登录状态
         this._webviewView.webview.postMessage({
           messageType: "sessionUpdate",
           data: {
@@ -164,7 +193,8 @@ export class ContinueGUIWebviewViewProvider
   }
 
   /**
-   * 更新 Webview 的 HTML 内容（始终显示 React 应用）
+   * 刷新 Webview 内容
+   * @param force 是否强制重载
    */
   private async updateWebviewHtml(force = false) {
     if (!this._webviewView) {
@@ -179,14 +209,30 @@ export class ContinueGUIWebviewViewProvider
   private _webview?: vscode.Webview;
   private _webviewView?: vscode.WebviewView;
 
+  /**
+   * 视图是否已准备就绪
+   */
+  get isReady() {
+    return !!this._webview;
+  }
+
+  /**
+   * 视图是否可见
+   */
   get isVisible() {
     return this._webviewView?.visible;
   }
 
+  /**
+   * 获取当前的 Webview 实例
+   */
   get webview() {
     return this._webview;
   }
 
+  /**
+   * 重置通讯协议中的 Webview 引用（通常在 Webview 重建后调用）
+   */
   public resetWebviewProtocolWebview(): void {
     if (!this._webview) {
       console.warn("no webview found during reset");
@@ -195,6 +241,9 @@ export class ContinueGUIWebviewViewProvider
     this.webviewProtocol.webview = this._webview;
   }
 
+  /**
+   * 向前端发送用户输入（用于命令行触发等场景）
+   */
   sendMainUserInput(input: string) {
     this.webview?.postMessage({
       type: "userInput",
@@ -202,16 +251,21 @@ export class ContinueGUIWebviewViewProvider
     });
   }
 
+  /**
+   * 生成 Webview 的 HTML 模板内容
+   * 包含 React 的入口 JS、CSS，以及注入到 window 全局变量中的各种初始状态
+   */
   getSidebarContent(
     context: vscode.ExtensionContext | undefined,
     panel: vscode.WebviewPanel | vscode.WebviewView,
-    page: string | undefined = undefined,
-    edits: FileEdit[] | undefined = undefined,
-    isFullScreen = false,
+    page: string | undefined = undefined, // 初始路由路径
+    edits: FileEdit[] | undefined = undefined, // 初始编辑数据
+    isFullScreen = false, // 是否全屏模式
   ): string {
     const extensionUri = getExtensionUri();
     let scriptUri: string;
     let styleMainUri: string;
+    // 基础路径
     const vscMediaUrl: string = panel.webview
       .asWebviewUri(vscode.Uri.joinPath(extensionUri, "gui"))
       .toString();
@@ -219,12 +273,15 @@ export class ContinueGUIWebviewViewProvider
       .asWebviewUri(vscode.Uri.joinPath(extensionUri, "media", "icon.png"))
       .toString();
 
+    // 判断开发模式还是生产模式，加载不同的静态资源
     const inDevelopmentMode =
       context?.extensionMode === vscode.ExtensionMode.Development;
     if (inDevelopmentMode) {
+      // 开发模式连接 Vite 热更新服务器
       scriptUri = "http://localhost:5173/src/main.tsx";
       styleMainUri = "http://localhost:5173/src/index.css";
     } else {
+      // 生产模式加载本地 assets
       scriptUri = panel.webview
         .asWebviewUri(vscode.Uri.joinPath(extensionUri, "gui/assets/index.js"))
         .toString();
@@ -233,6 +290,7 @@ export class ContinueGUIWebviewViewProvider
         .toString();
     }
 
+    // 配置 Webview 的本地资源映射
     panel.webview.options = {
       enableScripts: true,
       localResourceRoots: [
@@ -251,6 +309,7 @@ export class ContinueGUIWebviewViewProvider
 
     const nonce = getNonce();
 
+    // 获取并监听主题颜色变化
     const currentTheme = getTheme();
     vscode.workspace.onDidChangeConfiguration((e) => {
       if (
@@ -262,13 +321,14 @@ export class ContinueGUIWebviewViewProvider
         e.affectsConfiguration("workbench.preferredHighContrastColorTheme") ||
         e.affectsConfiguration("workbench.preferredHighContrastLightColorTheme")
       ) {
-        // Send new theme to GUI to update embedded Monaco themes
+        // 主题变化时通知前端，以便更新内嵌的 Monaco 编辑器等
         void this.webviewProtocol?.request("setTheme", { theme: getTheme() });
       }
     });
 
     this.webviewProtocol.webview = panel.webview;
 
+    // 返回完整的 HTML 字符串，通过 script 标签将变量注入到前端 window 对象
     return `<!DOCTYPE html>
     <html lang="en">
       <head>
@@ -285,6 +345,7 @@ export class ContinueGUIWebviewViewProvider
         ${
           inDevelopmentMode
             ? `<script type="module">
+          // Vite 热更新相关的运行时脚本
           import RefreshRuntime from "http://localhost:5173/@react-refresh"
           RefreshRuntime.injectIntoGlobalHook(window)
           window.$RefreshReg$ = () => {}

--- a/extensions/vscode/src/activation/localServer.ts
+++ b/extensions/vscode/src/activation/localServer.ts
@@ -37,6 +37,11 @@ export class LocalLoginServer {
   }>();
 
   /**
+   * 存储挂起的 HTTP 响应对象，键为 stateId
+   */
+  private _pendingResponses = new Map<string, http.ServerResponse>();
+
+  /**
    * 暴露给外部的只读事件
    * 其他模块通过订阅此事件来获取登录授权码。
    */
@@ -220,25 +225,58 @@ export class LocalLoginServer {
       return;
     }
 
+    // 将响应对象暂存，等待插件完成用户信息获取后再返回结果
+    this._pendingResponses.set(state, res);
+
     // 核心操作：通过 EventEmitter 将捕获到的授权数据直接分发给插件内部监听者
     this._onCodeReceived.fire({ code, state });
 
+    // 设置超时清理，防止内存泄漏（30秒后如果还没调用 finishResponse，则自动返回错误）
+    setTimeout(() => {
+      const pendingRes = this._pendingResponses.get(state);
+      if (pendingRes === res) {
+        this.finishResponse(state, false, "登录请求超时，请重试。");
+      }
+    }, 30000);
+  }
+
+  /**
+   * 结束挂起的 HTTP 响应
+   * @param state 校验标识
+   * @param success 是否成功
+   * @param message 显示的消息内容
+   */
+  public finishResponse(state: string, success: boolean, message?: string) {
+    const res = this._pendingResponses.get(state);
+    if (!res) {
+      return;
+    }
+
+    this._pendingResponses.delete(state);
+
     const scheme = getvsCodeUriScheme();
     const extensionId = this.context.extension.id;
-    const vscodeRedirectUrl = `${scheme}://${extensionId}/auth?code=${code}&state=${state}`;
 
-    // 向浏览器返回响应界面
+    // 如果是成功状态，依然尝试通过 URI Scheme 唤起编辑器
+    let redirectScript = "";
+    if (success) {
+      // 这里的 code 已经在 handleCallback 中通过事件发出了，这里只需要一个占位的 redirectUrl
+      const vscodeRedirectUrl = `${scheme}://${extensionId}/auth?state=${state}`;
+      redirectScript = `
+        <script>
+          window.location.href = "${vscodeRedirectUrl}";
+        </script>
+      `;
+    }
+
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
     res.end(`
       <html>
         <body style="display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100vh; font-family: sans-serif; background-color: #1e1e1e; color: #ccc;">
-          <h1>登录成功！</h1>
-          <p>正在为您跳转回编辑器...</p>
-          <p style="font-size: 0.8em; color: #888;">如果浏览器没有自动跳转，请手动返回。</p>
-          <script>
-            // 原理：通过 URI Scheme 唤起 VS Code，这会强制操作系统将焦点切换回编辑器
-            window.location.href = "${vscodeRedirectUrl}";
-          </script>
+          <h1>${success ? "登录成功！" : "登录失败"}</h1>
+          <p>${message || (success ? "正在为您跳转回编辑器..." : "请检查配置或重试。")}</p>
+          ${success ? '<p style="font-size: 0.8em; color: #888;">如果浏览器没有自动跳转，请手动返回。</p>' : ""}
+          ${redirectScript}
         </body>
       </html>
     `);
@@ -253,5 +291,6 @@ export class LocalLoginServer {
       this.server.close();
       this.server = null;
     }
+    this._pendingResponses.clear();
   }
 }

--- a/extensions/vscode/src/stubs/WorkOsAuthProvider.ts
+++ b/extensions/vscode/src/stubs/WorkOsAuthProvider.ts
@@ -1,16 +1,26 @@
+// 导入 Node.js 加密模块
 import crypto from "crypto";
+// 导入 Node.js HTTPS 模块
+import https from "https";
+// 导入 Node.js 事件触发器模块
 import { EventEmitter as NodeEventEmitter } from "node:events";
 
+// 导入核心逻辑中的身份验证相关类型和工具
 import {
   AuthType,
   ControlPlaneEnv,
   ControlPlaneSessionInfo,
   isHubEnv
 } from "core/control-plane/AuthTypes";
+// 导入获取控制面环境配置的工具函数
 import { getControlPlaneEnvSync } from "core/control-plane/env";
+// 导入日志记录工具
 import { Logger } from "core/util/Logger";
+// 导入用于网络请求的 node-fetch 库
 import fetch from "node-fetch";
+// 导入 UUID 生成工具
 import { v4 as uuidv4 } from "uuid";
+// 导入 VS Code API 及其常用类定义
 import * as vscode from "vscode";
 import {
   authentication,
@@ -25,18 +35,28 @@ import {
   window
 } from "vscode";
 
+// 导入本地登录服务器类
 import { LocalLoginServer } from "../activation/localServer";
+// 导入 Promise 适配器和事件转 Promise 的工具
 import { PromiseAdapter, promiseFromEvent } from "./promiseUtils";
+// 导入私密存储封装类
 import { SecretStorage } from "./SecretStorage";
+// 导入 URI 事件处理器类
 import { UriEventHandler } from "./uriHandler";
 
+// 身份验证提供者的名称
 const AUTH_NAME = "Continue";
 
+// 同步获取当前的控制面环境配置
 const controlPlaneEnv = getControlPlaneEnvSync(true ? "production" : "none");
 
+// 存储会话信息的 SecretStorage 键名
 const SESSIONS_SECRET_KEY = `${controlPlaneEnv.AUTH_TYPE}.sessions`;
 
-// Function to generate a random string of specified length
+/**
+ * 生成指定长度的随机字符串，通常用于 OAuth 的 state 或 code_verifier
+ * @param length 字符串长度
+ */
 function generateRandomString(length: number): string {
   const possibleCharacters =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
@@ -48,13 +68,15 @@ function generateRandomString(length: number): string {
   return randomString;
 }
 
-// Function to generate a code challenge from the code verifier
-
+/**
+ * 根据 code_verifier 生成 code_challenge（用于 PKCE 流程）
+ * @param verifier 验证字符串
+ */
 async function generateCodeChallenge(verifier: string) {
-  // Create a SHA-256 hash of the verifier
+  // 对验证字符串进行 SHA-256 哈希
   const hash = crypto.createHash("sha256").update(verifier).digest();
 
-  // Convert the hash to a base64 URL-encoded string
+  // 将哈希值转换为 Base64 URL 编码格式
   const base64String = hash
     .toString("base64")
     .replace(/\+/g, "-")
@@ -64,34 +86,55 @@ async function generateCodeChallenge(verifier: string) {
   return base64String;
 }
 
+/**
+ * 扩展 VS Code 的标准身份验证会话，添加刷新令牌和过期时间
+ */
 interface ContinueAuthenticationSession extends AuthenticationSession {
-  refreshToken: string;
-  expiresInMs: number;
-  loginNeeded: boolean;
+  refreshToken: string; // 刷新令牌
+  expiresInMs: number; // 过期时间（毫秒）
+  loginNeeded: boolean; // 是否需要重新登录
 }
 
+/**
+ * 基于 WorkOS 或自定义 OAuth 流程的身份验证提供者实现
+ */
 export class WorkOsAuthProvider implements AuthenticationProvider, Disposable {
+  // 会话变更事件触发器
   private _sessionChangeEmitter =
     new EventEmitter<AuthenticationProviderAuthenticationSessionsChangeEvent>();
+  // 资源释放列表
   private _disposable: Disposable;
+  // 等待回调的 state 列表
   private _pendingStates: string[] = [];
+  // 存储正在进行的授权码交换 Promise
   private _codeExchangePromises = new Map<
     string,
     { promise: Promise<string>; cancel: EventEmitter<void> }
   >();
+  // 刷新定时器
   private _refreshInterval: NodeJS.Timeout | null = null;
+  // 是否正在刷新中
   private _isRefreshing = false;
 
-  private static EXPIRATION_TIME_MS = 1000 * 60 * 15; // 15 minutes
-  private static REFRESH_INTERVAL_MS = 1000 * 60 * 10; // 10 minutes
+  // 默认过期时间（15分钟）和刷新间隔（10分钟）
+  private static EXPIRATION_TIME_MS = 1000 * 60 * 15;
+  private static REFRESH_INTERVAL_MS = 1000 * 60 * 10;
 
+  // 私密存储实例
   private secretStorage: SecretStorage;
 
+  /**
+   * 构造函数
+   * @param context 扩展上下文
+   * @param _uriHandler 处理 vscode:// 回调的处理器
+   * @param _localLoginServer 处理 http://127.0.0.1 回调的本地服务器
+   */
   constructor(
     private readonly context: ExtensionContext,
     private readonly _uriHandler: UriEventHandler,
     private readonly _localLoginServer?: LocalLoginServer,
   ) {
+    // 注册自身为 VS Code 的身份验证提供者，并注册 URI 处理器
     this._disposable = Disposable.from(
       authentication.registerAuthenticationProvider(
         controlPlaneEnv.AUTH_TYPE,
@@ -102,49 +145,60 @@ export class WorkOsAuthProvider implements AuthenticationProvider, Disposable {
       window.registerUriHandler(this._uriHandler),
     );
 
+    // 初始化私密存储工具，传入扩展上下文 context 以访问 VS Code 安全存储 API
     this.secretStorage = new SecretStorage(context);
 
-    // Initialize refresh-attempt gate for downstream flows
+    // 初始化刷新尝试机制
+    // 初始化刷新尝试的事件触发器
     this.attemptEmitter = new NodeEventEmitter();
+    // 创建一个静态 Promise，用于协调下游流程：当监听到 "attempted" 事件时 resolve
+    // 这样其他组件可以等待 WorkOsAuthProvider 完成初次的会话刷新尝试
     WorkOsAuthProvider.hasAttemptedRefresh = new Promise((resolve) => {
       this.attemptEmitter.on("attempted", resolve);
     });
 
-    // Disable session auto-refresh: immediately unblock dependent flows
+    // 禁用自动刷新，立即解开下游流程
     this.attemptEmitter.emit("attempted");
   }
 
+  /**
+   * 解码 JWT 令牌
+   * @param jwt JWT 字符串
+   */
   private decodeJwt(jwt: string): Record<string, any> | null {
-    // 保护原理：增加判空检查，防止因 jwt 未定义导致读取 length 属性出错
     if (!jwt) {
       return null;
     }
 
     try {
-      // 模拟原理：如果是模拟 Token，返回一个一年后过期的载荷
+      // 如果是模拟令牌，返回长期不过期的载荷
       if (jwt.startsWith("sim_")) {
         return {
           exp: Math.floor(Date.now() / 1000) + 3600 * 24 * 365,
         };
       }
 
+      // 解码 Base64 格式的载荷部分
       const decodedToken = JSON.parse(
         Buffer.from(jwt.split(".")[1], "base64").toString(),
       );
       return decodedToken;
     } catch (e: any) {
-      // Capture JWT decoding failures to Sentry (could indicate token corruption)
+      // 记录解码失败到日志
       Logger.error(e, {
         context: "workOS_auth_jwt_decode",
         jwtLength: jwt ? jwt.length : 0,
-        jwtPrefix: jwt ? jwt.substring(0, 20) + "..." : "none", // Safe prefix for debugging
+        jwtPrefix: jwt ? jwt.substring(0, 20) + "..." : "none",
       });
 
-      console.warn(`Error decoding JWT: ${e}`);
+      console.warn(`解码 JWT 出错: ${e}`);
       return null;
     }
   }
 
+  /**
+   * 检查 JWT 是否已过期或无效
+   */
   private jwtIsExpiredOrInvalid(jwt: string): boolean {
     const decodedToken = this.decodeJwt(jwt);
     if (!decodedToken) {
@@ -153,6 +207,9 @@ export class WorkOsAuthProvider implements AuthenticationProvider, Disposable {
     return decodedToken.exp * 1000 < Date.now();
   }
 
+  /**
+   * 获取令牌的有效时长（毫秒）
+   */
   private getExpirationTimeMs(jwt: string): number {
     const decodedToken = this.decodeJwt(jwt);
     if (!decodedToken) {
@@ -163,24 +220,33 @@ export class WorkOsAuthProvider implements AuthenticationProvider, Disposable {
       : WorkOsAuthProvider.EXPIRATION_TIME_MS;
   }
 
+  /**
+   * 将会话列表持久化存储到 SecretStorage
+   */
   private async storeSessions(value: ContinueAuthenticationSession[]) {
     const data = JSON.stringify(value, null, 2);
     await this.secretStorage.store(SESSIONS_SECRET_KEY, data);
   }
 
+  /**
+   * 获取当前存储的所有会话
+   * @param scopes 权限范围（可选）
+   */
   public async getSessions(
     scopes?: string[],
   ): Promise<ContinueAuthenticationSession[]> {
-    // await this.hasAttemptedRefresh;
     try {
+      // 从私密存储中获取加密存储的会话 JSON 字符串
       const data = await this.secretStorage.get(SESSIONS_SECRET_KEY);
+      // 如果存储中没有数据，说明用户未登录，返回空数组
       if (!data) {
         return [];
       }
 
+      // 将 JSON 字符串解析为会话对象数组
       const value = JSON.parse(data) as ContinueAuthenticationSession[];
 
-      // 检查登录状态并通知 VS Code
+      // 同步登录状态到 VS Code 上下文，以便控制 UI 显示
       const env = getControlPlaneEnvSync("production");
       void vscode.commands.executeCommand(
         "setContext",
@@ -190,21 +256,20 @@ export class WorkOsAuthProvider implements AuthenticationProvider, Disposable {
 
       return value;
     } catch (e: any) {
-      // Capture session decrypt and parsing errors to Sentry
+      // 处理解密或解析失败，防止插件崩溃
       Logger.error(e, {
         context: "workOS_sessions_retrieval",
         errorMessage: e.message,
       });
 
-      console.warn(`Error retrieving or parsing sessions: ${e.message}`);
+      console.warn(`检索或解析会话出错: ${e.message}`);
 
-      // Delete the corrupted cache file to allow fresh start on next attempt
-      // This handles cases where decryption succeeded but JSON parsing failed
+      // 如果数据损坏，删除缓存以便下次重试
       try {
         await this.secretStorage.delete(SESSIONS_SECRET_KEY);
       } catch (deleteError: any) {
         console.error(
-          `Failed to delete corrupted sessions cache:`,
+          `删除损坏的会话缓存失败:`,
           deleteError.message,
         );
       }
@@ -213,20 +278,29 @@ export class WorkOsAuthProvider implements AuthenticationProvider, Disposable {
     }
   }
 
+  /**
+   * 监听会话变更事件
+   */
   get onDidChangeSessions() {
     return this._sessionChangeEmitter.event;
   }
 
+  /**
+   * 获取 IDE 端的重定向 URI
+   */
   get ideRedirectUri() {
-    // We redirect to a page that says "you can close this page", and that page finishes the redirect
     const url = new URL(controlPlaneEnv.APP_URL);
     url.pathname = `/auth/${env.uriScheme}-redirect`;
     return url.toString();
   }
 
+  // 静态标记，控制是否使用 onboarding URI
   public static useOnboardingUri: boolean = false;
+  /**
+   * 获取 OAuth 流程的重定向回调 URI
+   */
   get redirectUri() {
-    // 使用本地服务器端口作为回调地址
+    // 优先使用本地服务器端口作为回调地址，提升成功率
     const url = new URL(
       `http://${LocalLoginServer.HOST}:${LocalLoginServer.PORT}`,
     );
@@ -234,14 +308,21 @@ export class WorkOsAuthProvider implements AuthenticationProvider, Disposable {
     return url.toString();
   }
 
+  // 静态 Promise，用于标识是否已经尝试过刷新会话，供外部（如 getControlPlaneSessionInfo）同步等待
   public static hasAttemptedRefresh: Promise<void>;
+  // 内部事件触发器，用于控制 hasAttemptedRefresh 的状态切换
   private attemptEmitter: NodeEventEmitter;
+  /**
+   * 刷新会话（目前已禁用自动刷新逻辑）
+   */
   async refreshSessions() {
-    // Disable session refresh, only signal that refresh has been attempted.
     this.attemptEmitter.emit("attempted");
     return;
   }
 
+  /**
+   * 格式化用户姓名显示
+   */
   private _formatProfileLabel(
     firstName: string | null,
     lastName: string | null,
@@ -250,77 +331,94 @@ export class WorkOsAuthProvider implements AuthenticationProvider, Disposable {
   }
 
   /**
-   * Create a new auth session
-   * @param scopes
-   * @returns
+   * 创建新的身份验证会话（核心登录流程）
+   * @param scopes 权限范围
    */
   public async createSession(
     scopes: string[],
   ): Promise<ContinueAuthenticationSession> {
     try {
       console.log("AuthProvider: createSession 被调用");
+      // 生成 PKCE 验证码
       const codeVerifier = generateRandomString(64);
       const codeChallenge = await generateCodeChallenge(codeVerifier);
 
-      // 如果不是 HubEnv，则要求必须配置了 APP_URL 才能登录
+      // 检查环境配置
       if (!isHubEnv(controlPlaneEnv) && !controlPlaneEnv.APP_URL) {
-        throw new Error("Login is disabled");
+        throw new Error("登录功能已禁用");
       }
 
       console.log("AuthProvider: 准备调用 login 方法");
-      const token = await this.login(codeChallenge, controlPlaneEnv, scopes);
-      if (!token) {
-        // 当用户关闭浏览器未授权，或者授权超时时，抛出明确错误
-        throw new Error(`User cancelled login or login timed out`);
+      // 调用登录逻辑，打开浏览器并等待授权码回调
+      const loginResult = await this.login(codeChallenge, controlPlaneEnv, scopes);
+      if (!loginResult) {
+        throw new Error(`用户取消登录或授权超时`);
       }
+      const { token, stateId } = loginResult;
 
       console.log("AuthProvider: 获取到 Token，准备获取用户信息");
-      const userInfo = (await this.getUserInfo(
-        token,
-        codeVerifier,
-        controlPlaneEnv,
-      )) as any;
-      // const { user, access_token, refresh_token } = userInfo;
+      // 使用授权码交换用户信息
+      let userInfo;
+      try {
+        userInfo = (await this.getUserInfo(
+          token,
+          codeVerifier,
+          controlPlaneEnv,
+        )) as any;
+
+        // 如果获取用户信息成功，通知本地服务器返回成功页面
+        this._localLoginServer?.finishResponse(stateId, true);
+      } catch (err) {
+        // 如果获取用户信息失败，通知本地服务器返回失败页面
+        this._localLoginServer?.finishResponse(stateId, false, `用户信息: ${err}`);
+        throw err;
+      }
+
       const { ccid, userName, deptName } = userInfo;
 
+      // 构造 VS Code 会话对象
+      // 构造符合 VS Code 标准且包含扩展信息的会话对象
       const session: ContinueAuthenticationSession = {
-        id: uuidv4(),
-        accessToken: token,
-        refreshToken: token,
-        expiresInMs: this.getExpirationTimeMs(token),
-        loginNeeded: false,
+        id: uuidv4(), // 生成会话的唯一标识符
+        accessToken: token, // 存储获取到的访问令牌
+        refreshToken: token, // 存储刷新令牌（在此流程中与访问令牌一致）
+        expiresInMs: this.getExpirationTimeMs(token), // 计算并设置令牌的有效期（毫秒）
+        loginNeeded: false, // 标记当前不需要重新登录
         account: {
-          label: `${userName} (${deptName})`,
-          id: ccid,
+          label: `${userName} (${deptName})`, // 在 VS Code 账户列表中显示的标签，格式为“姓名 (部门)”
+          id: ccid, // 用户的唯一 ID（如员工工号或系统 ID）
         },
-        scopes: [],
+        scopes: [], // 权限范围，目前为空
       };
 
+      // 存储会话并通知 VS Code
       await this.storeSessions([session]);
 
+      // 触发会话变更事件，通知 VS Code 身份验证系统有一个新会话已添加
+      // 这会同步触发 VS Code UI 更新，并通知其他监听该身份验证提供者的组件
       this._sessionChangeEmitter.fire({
-        added: [session],
-        removed: [],
-        changed: [],
+        added: [session], // 新增的会话对象数组
+        removed: [],      // 被移除的会话对象数组
+        changed: [],      // 已修改的会话对象数组
       });
 
       return session;
     } catch (e) {
-      // Capture authentication failures to Sentry
+      // 记录登录失败到日志并弹出错误提示
       Logger.error(e, {
         context: "workOS_auth_session_creation",
         scopes: scopes.join(","),
         authType: controlPlaneEnv.AUTH_TYPE,
       });
 
-      void window.showErrorMessage(`Sign in failed: ${e}`);
+      void window.showErrorMessage(`登录失败: ${e}`);
       throw e;
     }
   }
 
   /**
-   * Remove an existing session
-   * @param sessionId
+   * 删除指定的会话（退出登录）
+   * @param sessionId 会话 ID
    */
   public async removeSession(sessionId: string): Promise<void> {
     const sessions = await this.getSessions();
@@ -340,7 +438,7 @@ export class WorkOsAuthProvider implements AuthenticationProvider, Disposable {
   }
 
   /**
-   * Dispose the registered services
+   * 释放资源
    */
   public async dispose() {
     if (this._refreshInterval) {
@@ -351,29 +449,34 @@ export class WorkOsAuthProvider implements AuthenticationProvider, Disposable {
   }
 
   /**
-   * Log in to Continue
+   * 登录核心逻辑：打开浏览器并监听授权码回调
+   * @param codeChallenge PKCE 质询码
+   * @param controlPlaneEnv 环境配置
+   * @param scopes 权限范围
    */
   private async login(
     codeChallenge: string,
     controlPlaneEnv: ControlPlaneEnv,
     scopes: string[] = [],
-  ) {
+  ): Promise<{ token: string; stateId: string } | undefined> {
     console.log("AuthProvider: 进入 login 方法");
+    // 生成一个唯一的会话状态 ID (stateId)，用于 OAuth 安全校验，防止 CSRF 攻击
     const stateId = uuidv4();
 
+    // 将生成的 stateId 存入挂起状态列表，以便在回调时进行校验
     this._pendingStates.push(stateId);
 
+    // 将权限范围数组转换为以空格分隔的字符串，用于标识不同的权限请求
     const scopeString = scopes.join(" ");
 
-    console.log("AuthProvider: 获取到环境配置", controlPlaneEnv);
+    // 从环境配置中获取控制面（Control Plane）的应用基础 URL
     const appUrl = controlPlaneEnv.APP_URL;
     if (!appUrl) {
       console.log("AuthProvider: appUrl 为空，直接返回");
       return;
     }
 
-    console.log("AuthProvider: 准备构造 URL:", appUrl);
-    console.log("AuthProvider: 准备构造 stateId:", stateId);
+    // 构造登录页面的 URL
     let loginUrl = appUrl;
     if (!loginUrl.endsWith(".html")) {
       if (!loginUrl.endsWith("/")) {
@@ -399,7 +502,7 @@ export class WorkOsAuthProvider implements AuthenticationProvider, Disposable {
       console.log(
         `AuthProvider: 准备调用 env.openExternal: ${oauthUrl.toString()}`,
       );
-      // 使用 Promise.resolve 包装 Thenable，以便使用 .catch 方法
+      // 调用系统浏览器打开授权页
       Promise.resolve(env.openExternal(Uri.parse(oauthUrl.toString())))
         .then((success) => {
           if (!success) {
@@ -412,67 +515,74 @@ export class WorkOsAuthProvider implements AuthenticationProvider, Disposable {
           console.error("AuthProvider: 调用 env.openExternal 抛出异常", err);
         });
     } else {
-      console.log("AuthProvider: oauthUrl 为空，直接返回");
       return;
     }
 
-    console.log("AuthProvider: 准备注册回调监听");
+    // 处理旧的 Promise 残留，确保单一登录流程
     const oldPromise = this._codeExchangePromises.get(scopeString);
     if (oldPromise) {
-      console.log("AuthProvider: 发现旧的 Promise 残留，先取消它");
       oldPromise.cancel.fire();
     }
 
+    // 注册 URI Handler 监听 (vscode:// 回调)
     const uriPromise = promiseFromEvent(
       this._uriHandler.event,
       this.handleUri(scopes),
     );
 
+    // 定义用于存储授权码交换逻辑的对象，包含一个 Promise 和一个用于取消监听的触发器
     let codeExchangePromise: { promise: Promise<string>; cancel: EventEmitter<void> };
 
+    // 如果启用了本地服务器，则同时通过 Race 竞争两个回调来源（本地服务器 vs 协议唤起）
     if (this._localLoginServer) {
-      console.log("AuthProvider: 同时开启本地服务器和 URI Handler 监听回调");
+      // 创建一个基于本地服务器事件的 Promise
       const localPromise = promiseFromEvent<{ code: string; state: string }, string>(
-        this._localLoginServer.onCodeReceived,
+        this._localLoginServer.onCodeReceived, // 监听本地服务器接收到的授权码事件
         async (data, resolve, reject) => {
+          // 校验回调中的 state 是否在挂起列表中，防止伪造请求
           if (this._pendingStates.some((n) => n === data.state)) {
-            resolve(data.code);
+            resolve(data.code); // 校验成功，返回授权码
           } else {
-            reject(new Error("State not found"));
+            reject(new Error("State 校验失败")); // 校验失败
           }
         },
       );
 
+      // 创建一个组合取消触发器，用于同时取消两个监听源
       const combinedCancel = new EventEmitter<void>();
       codeExchangePromise = {
+        // 使用 Promise.race，谁先返回授权码就用谁的结果（协议唤起 vs 本地服务器）
         promise: Promise.race([uriPromise.promise, localPromise.promise]),
         cancel: combinedCancel,
       };
 
+      // 当执行取消操作时，同时触发两个监听源的取消逻辑
       combinedCancel.event(() => {
         uriPromise.cancel.fire();
         localPromise.cancel.fire();
       });
     } else {
-      console.log("AuthProvider: 使用 URI Handler 监听回调");
+      // 如果没有本地服务器，则仅使用 URI 协议唤起作为唯一来源
       codeExchangePromise = uriPromise;
     }
+    // 将构造好的 Promise 对象存入映射表，以便后续管理
     this._codeExchangePromises.set(scopeString, codeExchangePromise);
 
-    console.log("AuthProvider: 开始等待 Promise.race，设置超时机制");
+    // 等待授权结果，设置 30 秒超时
     try {
-      return await Promise.race([
+      const token = await Promise.race([
         codeExchangePromise.promise,
         new Promise<string>(
           (_, reject) =>
             setTimeout(
-              () => reject(new Error("Login Cancelled by timeout")),
+              () => reject(new Error("登录因超时已取消")),
               0.5 * 60 * 1000,
-            ), // 0.5min timeout
+            ),
         ),
       ]);
+      return { token, stateId };
     } finally {
-      console.log("AuthProvider: Promise.race 结束，清理状态");
+      // 清理状态
       this._pendingStates = this._pendingStates.filter((n) => n !== stateId);
       codeExchangePromise?.cancel.fire();
       this._codeExchangePromises.delete(scopeString);
@@ -480,9 +590,8 @@ export class WorkOsAuthProvider implements AuthenticationProvider, Disposable {
   }
 
   /**
-   * Handle the redirect to VS Code (after sign in from Continue)
-   * @param scopes
-   * @returns
+   * 处理从 vscode:// 协议传回的 URI 回调
+   * @param scopes 权限范围
    */
   private handleUri: (
     scopes: readonly string[],
@@ -493,17 +602,17 @@ export class WorkOsAuthProvider implements AuthenticationProvider, Disposable {
       const state = query.get("state");
 
       if (!access_token) {
-        reject(new Error("No token"));
+        reject(new Error("未获取到令牌"));
         return;
       }
       if (!state) {
-        reject(new Error("No state"));
+        reject(new Error("未获取到 State"));
         return;
       }
 
-      // Check if it is a valid auth request started by the extension
+      // 校验 State 防止 CSRF 攻击
       if (!this._pendingStates.some((n) => n === state)) {
-        reject(new Error("State not found"));
+        reject(new Error("State 匹配失败"));
         return;
       }
 
@@ -511,56 +620,84 @@ export class WorkOsAuthProvider implements AuthenticationProvider, Disposable {
     };
 
   /**
-   * Get the user info from WorkOS
-   * @param token
-   * @returns
+   * 使用授权码获取详细的用户信息
+   * @param token 授权码
+   * @param codeVerifier PKCE 验证字符串
+   * @param controlPlaneEnv 环境配置
    */
   private async getUserInfo(
     token: string,
     codeVerifier: string,
     controlPlaneEnv: ControlPlaneEnv,
   ) {
-    // 模拟原理：如果 token 是以 "sim_" 开头的模拟授权码，直接返回模拟的用户信息。
-    // 这避免了向真实的 WorkOS API 发送无效请求，解决了模拟登录时因无法交换 Token 导致的报错。
+    // 模拟逻辑：如果授权码以 sim_ 开头，直接返回假数据，方便离线开发测试
     if (token && token.startsWith("sim_")) {
       return {
         ccid: "123456789",
-        userName: "developer",
-        deptName: "test",
+        userName: "开发人员",
+        deptName: "测试部",
         access_token:
           "sim_access_token_" + Math.random().toString(36).substring(7),
         refresh_token:
           "sim_refresh_token_" + Math.random().toString(36).substring(7),
       };
     }
+    try {
+      const appUrl = controlPlaneEnv.APP_URL;
+      if (!appUrl) {
+        throw new Error("未配置 APP_URL");
+      }
+      let userInfoUrl = appUrl;
+      if (!userInfoUrl.endsWith("/")) {
+        userInfoUrl += "/";
+      }
+      // 向后端请求详细的用户元数据
+      // 禁用证书校验以支持自签名证书
+      const agent = new https.Agent({
+        rejectUnauthorized: false,
+      });
 
-    const appUrl = controlPlaneEnv.APP_URL;
-    console.log("getUserInfo appUrl:" + appUrl);
-    if (!appUrl) {
-      throw new Error("APP_URL is not configured");
+      const resp = await fetch(`${userInfoUrl}authmanager/token/v1/${token}`, {
+        method: "get",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        agent: agent as any,
+      });
+      const text = await resp.text();
+      const res = JSON.parse(text);
+      const data = JSON.parse(res.data);
+      return data;
+    } catch (err: any) {
+      console.error("获取用户信息出错:", err);
+      // 使用jwt获取用户信息，兜底方案
+      const decodedToken = this.decodeJwt(token);
+      if (!decodedToken) {
+        throw "用户信息获取异常，请稍后再试";
+      }
+      const userId = decodedToken.userId;
+      const userName = decodedToken.userName;
+      const dept = decodedToken.dept;
+      return {
+        ccid: userId,
+        userName,
+        deptName:dept,
+      }
+      // throw err;
     }
-    let userInfoUrl = appUrl;
-    if (!userInfoUrl.endsWith("/")) {
-      userInfoUrl += "/";
-    }
-    const resp = await fetch(`${userInfoUrl}authmanager/token/v1/${token}`, {
-      method: "get",
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
-    const text = await resp.text();
-    const res = JSON.parse(text);
-    const data = JSON.parse(res.data);
-    return data;
   }
 }
 
+/**
+ * 获取控制面会话信息的辅助函数
+ * @param silent 是否静默获取（不弹窗提示登录）
+ * @param useOnboarding 是否使用新手引导 URI
+ */
 export async function getControlPlaneSessionInfo(
   silent: boolean,
   useOnboarding: boolean,
 ): Promise<ControlPlaneSessionInfo | undefined> {
-  // 如果既不是 HubEnv，也没有配置 APP_URL，则视为 OnPrem 模式
+  // 如果是私有化部署环境且未配置 URL，则返回默认类型
   if (!isHubEnv(controlPlaneEnv) && !controlPlaneEnv.APP_URL) {
     return {
       AUTH_TYPE: AuthType.OnPrem,
@@ -568,27 +705,36 @@ export async function getControlPlaneSessionInfo(
   }
 
   try {
+    // 如果指定了使用新手引导流程，则临时设置静态标记
     if (useOnboarding) {
       WorkOsAuthProvider.useOnboardingUri = true;
     }
+    // 等待身份验证提供者完成初次的刷新尝试（避免并发冲突）
     await WorkOsAuthProvider.hasAttemptedRefresh;
+    // 调用 VS Code 核心 API 获取身份验证会话
+    // silent: true 表示不弹窗；createIfNone: true 表示如果没有会话则触发登录流程
     const session = await authentication.getSession(
       controlPlaneEnv.AUTH_TYPE,
       [],
       silent ? { silent: true } : { createIfNone: true },
     );
+
+    // 如果未获取到会话（如用户取消登录），返回 undefined
     if (!session) {
       return undefined;
     }
+
+    // 封装并返回标准化的控制面会话信息
     return {
       AUTH_TYPE: controlPlaneEnv.AUTH_TYPE,
-      accessToken: session.accessToken,
+      accessToken: session.accessToken, // 访问令牌
       account: {
-        id: session.account.id,
-        label: session.account.label,
+        id: session.account.id, // 账户 ID
+        label: session.account.label, // 账户显示标签
       },
     };
   } finally {
+    // 无论成功还是失败，最后都重置新手引导标记，确保不影响后续请求
     WorkOsAuthProvider.useOnboardingUri = false;
   }
 }

--- a/gui/src/components/Layout.tsx
+++ b/gui/src/components/Layout.tsx
@@ -233,11 +233,12 @@ const Layout = () => {
   }, [isHome]);
 
   useEffect(() => {
-    if (isInitialLoading || session || !loginRequired) {
+    if (isInitialLoading || hasTriggeredAutoLoginRef.current) {
       return;
     }
 
-    if (hasTriggeredAutoLoginRef.current) {
+    if (session || !loginRequired) {
+      hasTriggeredAutoLoginRef.current = true;
       return;
     }
 

--- a/交接文档docs/2026-05-12（优化用户信息获取异常处理与 SSL 校验逻辑）.md
+++ b/交接文档docs/2026-05-12（优化用户信息获取异常处理与 SSL 校验逻辑）.md
@@ -1,0 +1,85 @@
+# 优化用户信息获取异常处理与 SSL 校验逻辑 (2026-05-12)
+
+## 修改说明
+
+本文档记录了针对私有化部署环境下获取用户信息失败、自签名证书报错以及登录流程卡死的修复过程。
+
+### 修改 A：引入核心 HTTPS 模块支持
+
+- **修改点**：在 `WorkOsAuthProvider.ts` 顶部引入 Node.js 原生 `https` 模块。
+- **原因**：为了在后续的 `fetch` 请求中创建自定义的 `https.Agent`。
+- **文件**: [WorkOsAuthProvider.ts](file:///d:/cai/vscode插件/continue-cai/extensions/vscode/src/stubs/WorkOsAuthProvider.ts)
+
+### 修改 B：getUserInfo 增加 SSL 证书跳过逻辑
+
+- **修改点**：在 `getUserInfo` 方法发起的 `fetch` 请求中，传入了 `{ agent: new https.Agent({ rejectUnauthorized: false }) }`。
+- **原理**：针对自签名证书（Self-signed Certificate）环境，强制跳过 SSL 证书合法性校验。
+- **解决问题**：解决了 `FetchError: self signed certificate in certificate chain` 导致的获取用户信息中断。
+- **文件**: [WorkOsAuthProvider.ts](file:///d:/cai/vscode插件/continue-cai/extensions/vscode/src/stubs/WorkOsAuthProvider.ts)
+
+### 修改 C：引入 JWT 兜底解码方案
+
+- **修改点**：在 `getUserInfo` 的 `catch` 块中增加了 JWT 解析逻辑。
+- **逻辑**：当后端接口由于网络原因或服务异常无法返回数据时，插件会尝试直接从 `accessToken` 中解码出 `userId`、`userName` 和 `dept`。
+- **解决问题**：即使后端用户信息接口挂掉，只要 Token 有效，用户依然能完成登录并进入插件主界面。
+- **文件**: [WorkOsAuthProvider.ts](file:///d:/cai/vscode插件/continue-cai/extensions/vscode/src/stubs/WorkOsAuthProvider.ts)
+
+### 修改 D：修复 ContinueGUIWebviewViewProvider 缺失属性
+
+- **修改点**：为 `ContinueGUIWebviewViewProvider` 类添加了 `isReady` 属性。
+- **解决问题**：修复了在执行 `npm run tsc:check` 时，`commands.ts` 因为无法访问 `sidebar.isReady` 而导致的编译错误。
+- **文件**: [ContinueGUIWebviewViewProvider.ts](file:///d:/cai/vscode插件/continue-cai/extensions/vscode/src/ContinueGUIWebviewViewProvider.ts)
+
+### 修改 E：修复登出后误触发自动登录逻辑
+
+- **修改点**：调整了 `Layout.tsx` 中 `useEffect` 的触发门控。
+- **逻辑**：将 `hasTriggeredAutoLoginRef` 的锁定逻辑前置。只要初始化完成，无论是否已登录，都立即上锁。
+- **解决问题**：解决了用户手动点击“退出登录”后，因 `session` 变化导致 `Layout` 误判定为“首次进入且未登录”，从而再次自动弹出登录框的问题。
+- **文件**: [Layout.tsx](file:///d:/cai/vscode插件/continue-cai/gui/src/components/Layout.tsx)
+
+### 修改 F：实现浏览器端登录成功状态与后端异步同步
+
+- **修改点**：
+  - **LocalLoginServer**：引入 `_pendingResponses` 映射表，支持挂起（Hold）HTTP 请求响应。
+  - **WorkOsAuthProvider**：在 `createSession` 流程中，获取 Token 后先调用 `getUserInfo`，待获取结果（成功或失败）后再通知本地服务器结束响应。
+- **原理**：将浏览器显示的“登录成功”从“收到授权码”延后到“成功交换用户信息”。
+- **解决问题**：解决了浏览器显示登录成功但插件端由于网络或配置原因获取用户信息失败，导致用户产生误解的问题。
+- **文件**: [LocalLoginServer.ts](file:///d:/cai/vscode插件/continue-cai/extensions/vscode/src/activation/localServer.ts)、[WorkOsAuthProvider.ts](file:///d:/cai/vscode插件/continue-cai/extensions/vscode/src/stubs/WorkOsAuthProvider.ts)
+
+---
+
+## 验证结果
+
+- **编译检查**：运行 `npm run tsc:check` 通过，无类型报错。
+- **环境适配**：在本地模拟登录测试中，不再弹出证书报错，用户信息能正确通过 JWT 兜底或接口获取。
+- **交互逻辑**：
+  - 手动退出登录后，界面保持在登录引导页，不会自动重弹登录框。
+  - 只有当插件后台真正拿到用户信息后，浏览器端才会显示“登录成功”；若接口报错，浏览器端会实时显示具体失败原因。
+- **稳定性**：解决了因 `commands.ts` 引用错误导致的潜在插件崩溃问题。
+
+---
+
+# 终端命令自动化策略优化 (2026-05-12)
+
+## 修改说明
+
+本文档记录了针对 `runTerminalCommand` 工具安全策略的优化，旨在平衡自动化效率与系统安全性。
+
+### 修改 H：优化 evaluateToolCallPolicy 逻辑以尊重用户配置
+
+- **修改点**：在 `runTerminalCommandTool` 定义中，修改 `evaluateToolCallPolicy` 的实现逻辑。
+- **具体逻辑**：
+  - 调用 `evaluateTerminalCommandSecurity` 获取安全评估结果。
+  - **降级处理**：若结果为 `disabled`（极高风险，如 `rm -rf /`），则将其改为 `allowedWithPermission`，从“直接拒绝”变为“弹窗申请人工确认”。
+  - **尊重配置**：对于其他所有结果（如 `npm install` 等高风险命令），直接返回用户设置的 `basePolicy`。
+- **原理**：原逻辑会无视用户设置的 `allowedWithoutPermission`，强制将高风险命令提升为需要确认。修改后，除了毁灭性命令保留确认环节外，其余命令完全遵循用户的自动化意愿。
+- **文件**: [runTerminalCommand.ts](file:///d:/cai/vscode插件/continue-cai/core/tools/definitions/runTerminalCommand.ts)
+
+---
+
+## 验证结果
+
+- **功能验证**：
+  - 当配置为 `allowedWithoutPermission` 时，执行 `npm install`、`python` 等常用命令不再弹出确认框。
+  - 执行 `rm -rf /` 等极度危险命令时，系统由原来的直接报错拦截改为弹出确认框。
+- **静态检查**：相关修改无 TS 编译错误。

--- a/交接文档docs/自签名证书信任配置指南.md
+++ b/交接文档docs/自签名证书信任配置指南.md
@@ -1,0 +1,87 @@
+# 自签名证书信任配置指南
+
+在插件开发或私有化部署环境中，如果遇到 `self signed certificate in certificate chain` 报错，说明 Node.js 拒绝了不信任的自签名证书。以下是三种解决方法：
+
+## 1. 操作系统级别（全局生效，最推荐）
+
+将证书添加到系统的“受信任的根证书颁发机构”中，这是最标准的做法。
+
+### Windows
+1. 双击证书文件（`.crt` 或 `.pem`）。
+2. 点击 **“安装证书...”**。
+3. 选择 **“本地计算机”**（需要管理员权限）。
+4. 选择 **“将所有的证书都放入下列存储”**，点击 **“浏览”**。
+5. 选择 **“受信任的根证书颁发机构”** (Trusted Root Certification Authorities)。
+6. 完成安装并重启 VS Code。
+
+### macOS
+1. 双击证书文件，系统会打开 **“钥匙串访问” (Keychain Access)**。
+2. 将证书拖入 **“系统”** 钥匙串。
+3. 双击证书，在 **“信任”** 选项中将 **“使用此证书时”** 设置为 **“始终信任”**。
+
+### Linux (Ubuntu/Debian)
+1. `sudo cp mycert.crt /usr/local/share/ca-certificates/`
+2. `sudo update-ca-certificates`
+
+---
+
+## 2. 插件配置级别（Continue 官方推荐）
+
+在 Continue 的配置文件中直接指定 CA 证书路径。
+
+在 `config.json` 或 `config.yaml` 中，为对应的模型添加 `requestOptions`：
+
+**JSON 格式 (`config.json`):**
+```json
+{
+  "models": [
+    {
+      "title": "My Local Model",
+      "requestOptions": {
+        "caBundlePath": "/path/to/your/cert.pem"
+      }
+    }
+  ]
+}
+```
+
+**YAML 格式 (`config.yaml`):**
+```yaml
+models:
+  - title: My Local Model
+    requestOptions:
+      caBundlePath: /path/to/your/cert.pem
+```
+
+---
+
+## 3. 环境变量级别（临时方案）
+
+通过环境变量让 Node.js 识别额外的证书，无需修改系统设置。
+
+- **Windows (PowerShell)**: `$env:NODE_EXTRA_CA_CERTS="C:\path\to\your\cert.pem"`
+- **macOS/Linux**: `export NODE_EXTRA_CA_CERTS="/path/to/your/cert.pem"`
+
+---
+
+## 4. 强制跳过校验（仅限开发环境）
+
+**警告：此方法会降低安全性，严禁在生产环境使用。**
+
+在代码中发起 `fetch` 请求时禁用校验：
+
+```typescript
+import https from "https";
+
+const agent = new https.Agent({
+  rejectUnauthorized: false,
+});
+
+const resp = await fetch(url, {
+  // ... 其他配置
+  agent: agent as any,
+});
+```
+
+或者设置全局环境变量：
+`process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";`


### PR DESCRIPTION
1. 核心修复：引入 HTTPS Agent 跳过 SSL 校验，并增加 JWT 兜底解码逻辑
2. 逻辑优化：修复登出后自动登录循环，实现浏览器与后端状态异步同步
3. 编译修复：补充 Provider 缺失属性，解决 tsc 检查报错
4. 策略调整：优化终端自动化执行逻辑，平衡效率与安全性
5. 文档完善：新增修改记录文档及自签名证书信任配置指南

## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
